### PR TITLE
Prmdr 163 migrate authorisation handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ env:
 zip:
 	rm -rf ./lambdas/package_$(lambda_name) || true 
 	mkdir ./lambdas/package_$(lambda_name)
-	./lambdas/venv/bin/pip3 install --cache-dir .pip_cache -r lambdas/requirements.txt -t ./lambdas/package_$(lambda_name)
+	./lambdas/venv/bin/pip3 install --platform manylinux2014_x86_64 --only-binary=:all: --implementation cp  -r lambdas/requirements.txt -t ./lambdas/package_$(lambda_name)
 	mkdir ./lambdas/package_$(lambda_name)/handlers
 	cp -r lambdas/handlers/$(lambda_name).py lambdas/package_$(lambda_name)/handlers
 	cp -r lambdas/utils lambdas/package_$(lambda_name)

--- a/lambdas/handlers/authoriser_handler.py
+++ b/lambdas/handlers/authoriser_handler.py
@@ -2,9 +2,12 @@
 This code has been modified from AWS blueprint. Below is the original license:
 
 Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License. A copy of the License is located at
      http://aws.amazon.com/apache2.0/
-or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+or in the "license" file accompanying this file.
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
 """
 
 import logging

--- a/lambdas/handlers/authoriser_handler.py
+++ b/lambdas/handlers/authoriser_handler.py
@@ -1,0 +1,254 @@
+"""
+Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+
+     http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+"""
+from __future__ import print_function
+
+import re
+
+
+def lambda_handler(event, context):
+    """Do not print the auth token unless absolutely necessary """
+    print("Client token: " + event['authorizationToken'])
+    print(f"incoming event: {event}")
+
+
+
+
+    # print("Method ARN: " + event['methodArn'])
+    """validate the incoming token"""
+    """and produce the principal user identifier associated with the token"""
+
+    """this could be accomplished in a number of ways:"""
+    """1. Call out to OAuth provider"""
+    """2. Decode a JWT token inline"""
+    """3. Lookup in a self-managed DB"""
+    principalId = "user|a1b2c3d4"
+
+    """you can send a 401 Unauthorized response to the client by failing like so:"""
+    """raise Exception('Unauthorized')"""
+
+    """if the token is valid, a policy must be generated which will allow or deny access to the client"""
+
+    """if access is denied, the client will recieve a 403 Access Denied response"""
+    """if access is allowed, API Gateway will proceed with the backend integration configured on the method that was called"""
+
+    """this function must generate a policy that is associated with the recognized principal user identifier."""
+    """depending on your use case, you might store policies in a DB, or generate them on the fly"""
+
+    """keep in mind, the policy is cached for 5 minutes by default (TTL is configurable in the authorizer)"""
+    """and will apply to subsequent calls to any method/resource in the RestApi"""
+    """made with the same token"""
+
+    """the example policy below denies access to all resources in the RestApi"""
+
+
+
+
+    tmp = event['methodArn'].split(':')
+    apiGatewayArnTmp = tmp[5].split('/')
+    awsAccountId = tmp[4]
+
+    policy = AuthPolicy(principalId, awsAccountId)
+    policy.restApiId = apiGatewayArnTmp[0]
+    policy.region = tmp[3]
+    policy.stage = apiGatewayArnTmp[1]
+
+    if event['authorizationToken'] == "test":
+        policy.allowAllMethods()
+    elif event['authorizationToken'] == "test_get":
+        policy.allowMethod(HttpVerb.GET, "/SearchDocumentReferences")
+    else:
+        policy.denyAllMethods()
+
+
+    # Finally, build the policy
+    authResponse = policy.build()
+    print(authResponse, "<--- auth response")
+
+    # new! -- add additional key-value pairs associated with the authenticated principal
+    # these are made available by APIGW like so: $context.authorizer.<key>
+    # additional context is cached
+    context = {
+        'key': 'value',  # $context.authorizer.key -> value
+        'number': 1,
+        'bool': True
+    }
+    # context['arr'] = ['foo'] <- this is invalid, APIGW will not accept it
+    # context['obj'] = {'foo':'bar'} <- also invalid
+
+    authResponse['context'] = context
+
+    return authResponse
+
+
+class HttpVerb:
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    HEAD = "HEAD"
+    DELETE = "DELETE"
+    OPTIONS = "OPTIONS"
+    ALL = "*"
+
+
+class AuthPolicy(object):
+    awsAccountId = ""
+    """The AWS account id the policy will be generated for. This is used to create the method ARNs."""
+    principalId = ""
+    """The principal used for the policy, this should be a unique identifier for the end user."""
+    version = "2012-10-17"
+    """The policy version used for the evaluation. This should always be '2012-10-17'"""
+    pathRegex = "^[/.a-zA-Z0-9-\*]+$"
+    """The regular expression used to validate resource paths for the policy"""
+
+    """these are the internal lists of allowed and denied methods. These are lists
+    of objects and each object has 2 properties: A resource ARN and a nullable
+    conditions statement.
+    the build method processes these lists and generates the approriate
+    statements for the final policy"""
+    allowMethods = []
+    denyMethods = []
+
+    restApiId = "<<restApiId>>"
+    """ Replace the placeholder value with a default API Gateway API id to be used in the policy. 
+    Beware of using '*' since it will not simply mean any API Gateway API id, because stars will greedily expand over '/' or other separators. 
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. """
+
+    region = "<<region>>"
+    """ Replace the placeholder value with a default region to be used in the policy. 
+    Beware of using '*' since it will not simply mean any region, because stars will greedily expand over '/' or other separators. 
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. """
+
+    stage = "<<stage>>"
+    """ Replace the placeholder value with a default stage to be used in the policy. 
+    Beware of using '*' since it will not simply mean any stage, because stars will greedily expand over '/' or other separators. 
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. """
+
+    def __init__(self, principal, awsAccountId):
+        self.awsAccountId = awsAccountId
+        self.principalId = principal
+        self.allowMethods = []
+        self.denyMethods = []
+
+    def _addMethod(self, effect, verb, resource, conditions):
+        """Adds a method to the internal lists of allowed or denied methods. Each object in
+        the internal list contains a resource ARN and a condition statement. The condition
+        statement can be null."""
+        if verb != "*" and not hasattr(HttpVerb, verb):
+            raise NameError("Invalid HTTP verb " + verb + ". Allowed verbs in HttpVerb class")
+        resourcePattern = re.compile(self.pathRegex)
+        if not resourcePattern.match(resource):
+            raise NameError("Invalid resource path: " + resource + ". Path should match " + self.pathRegex)
+
+        if resource[:1] == "/":
+            resource = resource[1:]
+
+        resourceArn = ("arn:aws:execute-api:" +
+                       self.region + ":" +
+                       self.awsAccountId + ":" +
+                       self.restApiId + "/" +
+                       self.stage + "/" +
+                       verb + "/" +
+                       resource)
+
+        if effect.lower() == "allow":
+            self.allowMethods.append({
+                'resourceArn': resourceArn,
+                'conditions': conditions
+            })
+        elif effect.lower() == "deny":
+            self.denyMethods.append({
+                'resourceArn': resourceArn,
+                'conditions': conditions
+            })
+
+    def _getEmptyStatement(self, effect):
+        """Returns an empty statement object prepopulated with the correct action and the
+        desired effect."""
+        statement = {
+            'Action': 'execute-api:Invoke',
+            'Effect': effect[:1].upper() + effect[1:].lower(),
+            'Resource': []
+        }
+
+        return statement
+
+    def _getStatementForEffect(self, effect, methods):
+        """This function loops over an array of objects containing a resourceArn and
+        conditions statement and generates the array of statements for the policy."""
+        statements = []
+
+        if len(methods) > 0:
+            statement = self._getEmptyStatement(effect)
+
+            for curMethod in methods:
+                if curMethod['conditions'] is None or len(curMethod['conditions']) == 0:
+                    statement['Resource'].append(curMethod['resourceArn'])
+                else:
+                    conditionalStatement = self._getEmptyStatement(effect)
+                    conditionalStatement['Resource'].append(curMethod['resourceArn'])
+                    conditionalStatement['Condition'] = curMethod['conditions']
+                    statements.append(conditionalStatement)
+
+            statements.append(statement)
+
+        return statements
+
+    def allowAllMethods(self):
+        """Adds a '*' allow to the policy to authorize access to all methods of an API"""
+        self._addMethod("Allow", HttpVerb.ALL, "*", [])
+
+    def denyAllMethods(self):
+        """Adds a '*' allow to the policy to deny access to all methods of an API"""
+        self._addMethod("Deny", HttpVerb.ALL, "*", [])
+
+    def allowMethod(self, verb, resource):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of allowed
+        methods for the policy"""
+        self._addMethod("Allow", verb, resource, [])
+
+    def denyMethod(self, verb, resource):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of denied
+        methods for the policy"""
+        self._addMethod("Deny", verb, resource, [])
+
+    def allowMethodWithConditions(self, verb, resource, conditions):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of allowed
+        methods and includes a condition for the policy statement. More on AWS policy
+        conditions here: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Condition"""
+        self._addMethod("Allow", verb, resource, conditions)
+
+    def denyMethodWithConditions(self, verb, resource, conditions):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of denied
+        methods and includes a condition for the policy statement. More on AWS policy
+        conditions here: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Condition"""
+        self._addMethod("Deny", verb, resource, conditions)
+
+    def build(self):
+        """Generates the policy document based on the internal lists of allowed and denied
+        conditions. This will generate a policy with two main statements for the effect:
+        one statement for Allow and one statement for Deny.
+        Methods that includes conditions will have their own statement in the policy."""
+        if ((self.allowMethods is None or len(self.allowMethods) == 0) and
+                (self.denyMethods is None or len(self.denyMethods) == 0)):
+            raise NameError("No statements defined for the policy")
+
+        policy = {
+            'principalId': self.principalId,
+            'policyDocument': {
+                'Version': self.version,
+                'Statement': []
+            }
+        }
+
+        policy['policyDocument']['Statement'].extend(self._getStatementForEffect("Allow", self.allowMethods))
+        policy['policyDocument']['Statement'].extend(self._getStatementForEffect("Deny", self.denyMethods))
+
+        return policy

--- a/lambdas/handlers/authoriser_handler.py
+++ b/lambdas/handlers/authoriser_handler.py
@@ -49,15 +49,14 @@ def lambda_handler(event, context):
     except KeyError as e:
         logger.error(e)
 
-    principalId = ""
-    tmp = event["methodArn"].split(":")
-    apiGatewayArnTmp = tmp[5].split("/")
-    awsAccountId = tmp[4]
+    principal_id = ""
+    _, _, _, region, aws_account_id, api_gateway_arn = event["methodArn"].split(":")
+    api_id, stage, http_verb, resource_name = api_gateway_arn.split("/")
 
-    policy = AuthPolicy(principalId, awsAccountId)
-    policy.restApiId = apiGatewayArnTmp[0]
-    policy.region = tmp[3]
-    policy.stage = apiGatewayArnTmp[1]
+    policy = AuthPolicy(principal_id, aws_account_id)
+    policy.restApiId = api_id
+    policy.region = region
+    policy.stage = stage
 
     if user == "GP":
         policy.allowAllMethods()
@@ -68,9 +67,9 @@ def lambda_handler(event, context):
     else:
         policy.denyAllMethods()
 
-    authResponse = policy.build()
+    auth_response = policy.build()
 
-    return authResponse
+    return auth_response
 
 
 class HttpVerb:

--- a/lambdas/handlers/authoriser_handler.py
+++ b/lambdas/handlers/authoriser_handler.py
@@ -27,7 +27,7 @@ def lambda_handler(event, context):
     ssm_public_key_parameter_name = os.environ["SSM_PARAM_JWT_TOKEN_PUBLIC_KEY"]
 
     try:
-        client = boto3.client("ssm")
+        client = boto3.client("ssm", region_name="eu-west-2")
         ssm_response = client.get_parameter(
             Name=ssm_public_key_parameter_name, WithDecryption=True
         )

--- a/lambdas/handlers/authoriser_handler.py
+++ b/lambdas/handlers/authoriser_handler.py
@@ -22,6 +22,7 @@ def lambda_handler(event, context):
     """Do not print the auth token unless absolutely necessary """
     print("Client token: " + event['authorizationToken'])
     print(f"incoming event: {event}")
+    user = 'Unauthorised'
     try:
         client = boto3.client('ssm')
         ssm_response = client.get_parameter(
@@ -35,11 +36,11 @@ def lambda_handler(event, context):
     except botocore.exceptions.ClientError as e:
         logger.error(e)
     except jwt.PyJWTError as e:
-        user = 'Unauthorised'
         logger.info(f"error while decoding JWT: {e}")
+    except KeyError as e:
+        logger.error(e)
 
     principalId = "user|a1b2c3d4"
-
     tmp = event['methodArn'].split(':')
     apiGatewayArnTmp = tmp[5].split('/')
     awsAccountId = tmp[4]

--- a/lambdas/handlers/authoriser_handler.py
+++ b/lambdas/handlers/authoriser_handler.py
@@ -1,14 +1,14 @@
 """
+This code has been modified from AWS blueprint. Below is the original license:
+
 Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-This code has been modified from AWS blueprint.
 Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
      http://aws.amazon.com/apache2.0/
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 """
 
-from __future__ import print_function
-
 import logging
+import os
 import re
 
 import boto3
@@ -18,31 +18,37 @@ import jwt
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 def lambda_handler(event, context):
-    """Do not print the auth token unless absolutely necessary """
-    print("Client token: " + event['authorizationToken'])
-    print(f"incoming event: {event}")
-    user = 'Unauthorised'
+    user = "Unauthorised"
+    ssm_public_key_parameter_name = os.environ["SSM_PARAM_JWT_TOKEN_PUBLIC_KEY"]
+
     try:
-        client = boto3.client('ssm')
+        client = boto3.client("ssm")
         ssm_response = client.get_parameter(
-        Name='jwt_token_public_key',
-        WithDecryption=True
+            Name=ssm_public_key_parameter_name, WithDecryption=True
         )
-        public_key = ssm_response['Parameter']['Value']
-        decoded = jwt.decode(event['authorizationToken'], public_key, algorithms=["RS256"])
-        user = decoded['user_role']
+        public_key = ssm_response["Parameter"]["Value"]
+
+        # For now we just assume the user authenticate with a signed token in this form:
+        # { "user_role": "Unauthorised"  or  "GP"  or  "PCSE" }
+        # The token is going to be issued by the lambda of ticket PRMDR-167
+
+        decoded = jwt.decode(
+            event["authorizationToken"], public_key, algorithms=["RS256"]
+        )
+        user = decoded["user_role"]
         logger.info(f"decoded JWT: {decoded}")
     except botocore.exceptions.ClientError as e:
         logger.error(e)
     except jwt.PyJWTError as e:
-        logger.info(f"error while decoding JWT: {e}")
+        logger.error(f"error while decoding JWT: {e}")
     except KeyError as e:
         logger.error(e)
 
-    principalId = "user|a1b2c3d4"
-    tmp = event['methodArn'].split(':')
-    apiGatewayArnTmp = tmp[5].split('/')
+    principalId = ""
+    tmp = event["methodArn"].split(":")
+    apiGatewayArnTmp = tmp[5].split("/")
     awsAccountId = tmp[4]
 
     policy = AuthPolicy(principalId, awsAccountId)
@@ -54,15 +60,15 @@ def lambda_handler(event, context):
         policy.allowAllMethods()
     elif user == "PCSE":
         policy.allowMethod(HttpVerb.GET, "/SearchDocumentReferences")
+    elif user == "SuperUser":
+        policy.allowAllMethods()
     else:
         policy.denyAllMethods()
 
-
     authResponse = policy.build()
 
-    authResponse['context'] = context
-
     return authResponse
+
 
 class HttpVerb:
     GET = "GET"
@@ -74,17 +80,18 @@ class HttpVerb:
     OPTIONS = "OPTIONS"
     ALL = "*"
 
+
 class AuthPolicy(object):
     awsAccountId = ""
     principalId = ""
     version = "2012-10-17"
-    pathRegex = "^[/.a-zA-Z0-9-\*]+$"
+    pathRegex = r"^[/.a-zA-Z0-9-*]+$"
     allowMethods = []
     denyMethods = []
 
-    restApiId = "<<restApiId>>"
-    region = "<<region>>"
-    stage = "<<stage>>"
+    restApiId = "<<restApiId>"
+    region = "eu-west-2"
+    stage = "dev"
 
     def __init__(self, principal, awsAccountId):
         self.awsAccountId = awsAccountId
@@ -97,40 +104,52 @@ class AuthPolicy(object):
         the internal list contains a resource ARN and a condition statement. The condition
         statement can be null."""
         if verb != "*" and not hasattr(HttpVerb, verb):
-            raise NameError("Invalid HTTP verb " + verb + ". Allowed verbs in HttpVerb class")
+            raise NameError(
+                "Invalid HTTP verb " + verb + ". Allowed verbs in HttpVerb class"
+            )
         resourcePattern = re.compile(self.pathRegex)
         if not resourcePattern.match(resource):
-            raise NameError("Invalid resource path: " + resource + ". Path should match " + self.pathRegex)
+            raise NameError(
+                "Invalid resource path: "
+                + resource
+                + ". Path should match "
+                + self.pathRegex
+            )
 
         if resource[:1] == "/":
             resource = resource[1:]
 
-        resourceArn = ("arn:aws:execute-api:" +
-                       self.region + ":" +
-                       self.awsAccountId + ":" +
-                       self.restApiId + "/" +
-                       self.stage + "/" +
-                       verb + "/" +
-                       resource)
+        resourceArn = (
+            "arn:aws:execute-api:"
+            + self.region
+            + ":"
+            + self.awsAccountId
+            + ":"
+            + self.restApiId
+            + "/"
+            + self.stage
+            + "/"
+            + verb
+            + "/"
+            + resource
+        )
 
         if effect.lower() == "allow":
-            self.allowMethods.append({
-                'resourceArn': resourceArn,
-                'conditions': conditions
-            })
+            self.allowMethods.append(
+                {"resourceArn": resourceArn, "conditions": conditions}
+            )
         elif effect.lower() == "deny":
-            self.denyMethods.append({
-                'resourceArn': resourceArn,
-                'conditions': conditions
-            })
+            self.denyMethods.append(
+                {"resourceArn": resourceArn, "conditions": conditions}
+            )
 
     def _getEmptyStatement(self, effect):
         """Returns an empty statement object prepopulated with the correct action and the
         desired effect."""
         statement = {
-            'Action': 'execute-api:Invoke',
-            'Effect': effect[:1].upper() + effect[1:].lower(),
-            'Resource': []
+            "Action": "execute-api:Invoke",
+            "Effect": effect[:1].upper() + effect[1:].lower(),
+            "Resource": [],
         }
 
         return statement
@@ -144,12 +163,12 @@ class AuthPolicy(object):
             statement = self._getEmptyStatement(effect)
 
             for curMethod in methods:
-                if curMethod['conditions'] is None or len(curMethod['conditions']) == 0:
-                    statement['Resource'].append(curMethod['resourceArn'])
+                if curMethod["conditions"] is None or len(curMethod["conditions"]) == 0:
+                    statement["Resource"].append(curMethod["resourceArn"])
                 else:
                     conditionalStatement = self._getEmptyStatement(effect)
-                    conditionalStatement['Resource'].append(curMethod['resourceArn'])
-                    conditionalStatement['Condition'] = curMethod['conditions']
+                    conditionalStatement["Resource"].append(curMethod["resourceArn"])
+                    conditionalStatement["Condition"] = curMethod["conditions"]
                     statements.append(conditionalStatement)
 
             statements.append(statement)
@@ -179,19 +198,21 @@ class AuthPolicy(object):
         conditions. This will generate a policy with two main statements for the effect:
         one statement for Allow and one statement for Deny.
         Methods that includes conditions will have their own statement in the policy."""
-        if ((self.allowMethods is None or len(self.allowMethods) == 0) and
-                (self.denyMethods is None or len(self.denyMethods) == 0)):
+        if (self.allowMethods is None or len(self.allowMethods) == 0) and (
+            self.denyMethods is None or len(self.denyMethods) == 0
+        ):
             raise NameError("No statements defined for the policy")
 
         policy = {
-            'principalId': self.principalId,
-            'policyDocument': {
-                'Version': self.version,
-                'Statement': []
-            }
+            "principalId": self.principalId,
+            "policyDocument": {"Version": self.version, "Statement": []},
         }
 
-        policy['policyDocument']['Statement'].extend(self._getStatementForEffect("Allow", self.allowMethods))
-        policy['policyDocument']['Statement'].extend(self._getStatementForEffect("Deny", self.denyMethods))
+        policy["policyDocument"]["Statement"].extend(
+            self._getStatementForEffect("Allow", self.allowMethods)
+        )
+        policy["policyDocument"]["Statement"].extend(
+            self._getStatementForEffect("Deny", self.denyMethods)
+        )
 
         return policy

--- a/lambdas/requirements.txt
+++ b/lambdas/requirements.txt
@@ -8,6 +8,7 @@ idna==3.4
 Jinja2==3.1.2
 jmespath==1.0.1
 MarkupSafe==2.1.3
+PyJWT==2.8.0
 pycparser==2.21
 pydantic==2.3.0
 python-dateutil==2.8.2

--- a/lambdas/tests/unit/handlers/test_authoriser_handler.py
+++ b/lambdas/tests/unit/handlers/test_authoriser_handler.py
@@ -1,0 +1,15 @@
+import jwt
+
+import lambdas.handlers.authoriser_handler as auth_lambda
+
+
+def test_token():
+    test_json = {
+        "test" : "test2",
+        "user_role" : "GP"
+    }
+    private_key = b"teststetst"
+    token = jwt.encode(test_json, private_key, algorithm="RS256")
+    event = {'authorizationToken' : token}
+    response = auth_lambda.lambda_handler(event=event)
+    assert test_json == response

--- a/lambdas/tests/unit/handlers/test_authoriser_handler.py
+++ b/lambdas/tests/unit/handlers/test_authoriser_handler.py
@@ -27,7 +27,7 @@ def mock_ssm_public_key():
         "os.environ", {"SSM_PARAM_JWT_TOKEN_PUBLIC_KEY": TEST_PUBLIC_KEY_SSM_PARAM_NAME}
     ):
         with mock_ssm():
-            ssm = boto3.client("ssm")
+            ssm = boto3.client("ssm", region_name="eu-west-2")
             ssm.put_parameter(
                 Name=TEST_PUBLIC_KEY_SSM_PARAM_NAME,
                 Value=TEST_PUBLIC_KEY,

--- a/lambdas/tests/unit/handlers/test_authoriser_handler.py
+++ b/lambdas/tests/unit/handlers/test_authoriser_handler.py
@@ -1,15 +1,44 @@
-import jwt
+from unittest.mock import patch
+import pytest
+import boto3
+from moto import mock_ssm
+from dataclasses import dataclass
 
-import lambdas.handlers.authoriser_handler as auth_lambda
+from handlers.authoriser_handler import lambda_handler as auth_lambda
+
+@pytest.fixture
+def context():
+    @dataclass
+    class LambdaContext:
+        pass
+    return LambdaContext()
+
+# def test_token():
+#     private_key = b"testtsdfushd"
+#     token = jwt.encode(test_json, private_key, algorithm="RS256")
+#     event = {'authorizationToken': token}
+#     auth_lambda.lambda_handler(event, context)
+
+@mock_ssm
+def test_valid_gp_token_return_allow_policy(context):
+    with patch("handler.jwt.decode") as decode_mock:
+        ssm = boto3.client('ssm')
+        ssm.put_parameter(
+            Name="jwt_token_public_key",
+            Value="test_public_key",
+            Type="SecureString",
+        )
+        event = {'authorizationToken': "valid_token"}
+        decode_mock.return_value = {'user_role' : 'GP'}
+        response = auth_lambda.lambda_handler(event, context)
+        print(response)
 
 
-def test_token():
-    test_json = {
-        "test" : "test2",
-        "user_role" : "GP"
-    }
-    private_key = b"teststetst"
-    token = jwt.encode(test_json, private_key, algorithm="RS256")
-    event = {'authorizationToken' : token}
-    response = auth_lambda.lambda_handler(event=event)
-    assert test_json == response
+def test_valid_pcse_token_return_allow_policy():
+    pass
+
+def test_invalid_token_return_deny_policy():
+    pass
+
+def test_invalid_signature_return_deny_policy():
+    pass

--- a/lambdas/tests/unit/handlers/test_authoriser_handler.py
+++ b/lambdas/tests/unit/handlers/test_authoriser_handler.py
@@ -1,13 +1,11 @@
+from dataclasses import dataclass
 from unittest.mock import patch
 
+import boto3
 import jwt
 import pytest
-import boto3
-from moto import mock_ssm
-from dataclasses import dataclass
-
 from handlers.authoriser_handler import lambda_handler
-
+from moto import mock_ssm
 
 MOCK_METHOD_ARN_PREFIX = "arn:aws:execute-api:eu-west-2:fake_arn:fake_api_endpoint/dev"
 TEST_PUBLIC_KEY = "test_public_key"
@@ -25,7 +23,9 @@ def context():
 
 @pytest.fixture()
 def mock_ssm_public_key():
-    with patch.dict("os.environ", {"SSM_PARAM_JWT_TOKEN_PUBLIC_KEY": TEST_PUBLIC_KEY_SSM_PARAM_NAME}):
+    with patch.dict(
+        "os.environ", {"SSM_PARAM_JWT_TOKEN_PUBLIC_KEY": TEST_PUBLIC_KEY_SSM_PARAM_NAME}
+    ):
         with mock_ssm():
             ssm = boto3.client("ssm")
             ssm.put_parameter(

--- a/lambdas/tests/unit/handlers/test_authoriser_handler.py
+++ b/lambdas/tests/unit/handlers/test_authoriser_handler.py
@@ -1,44 +1,147 @@
 from unittest.mock import patch
+
+import jwt
 import pytest
 import boto3
 from moto import mock_ssm
 from dataclasses import dataclass
 
-from handlers.authoriser_handler import lambda_handler as auth_lambda
+from handlers.authoriser_handler import lambda_handler
+
+
+MOCK_METHOD_ARN_PREFIX = "arn:aws:execute-api:eu-west-2:fake_arn:fake_api_endpoint/dev"
+TEST_PUBLIC_KEY = "test_public_key"
+TEST_PUBLIC_KEY_SSM_PARAM_NAME = "jwt_token_public_key"
+
 
 @pytest.fixture
 def context():
     @dataclass
     class LambdaContext:
         pass
+
     return LambdaContext()
 
-# def test_token():
-#     private_key = b"testtsdfushd"
-#     token = jwt.encode(test_json, private_key, algorithm="RS256")
-#     event = {'authorizationToken': token}
-#     auth_lambda.lambda_handler(event, context)
 
-@mock_ssm
-def test_valid_gp_token_return_allow_policy(context):
-    with patch("handler.jwt.decode") as decode_mock:
-        ssm = boto3.client('ssm')
-        ssm.put_parameter(
-            Name="jwt_token_public_key",
-            Value="test_public_key",
-            Type="SecureString",
-        )
-        event = {'authorizationToken': "valid_token"}
-        decode_mock.return_value = {'user_role' : 'GP'}
-        response = auth_lambda.lambda_handler(event, context)
-        print(response)
+@pytest.fixture()
+def mock_ssm_public_key():
+    with patch.dict("os.environ", {"SSM_PARAM_JWT_TOKEN_PUBLIC_KEY": TEST_PUBLIC_KEY_SSM_PARAM_NAME}):
+        with mock_ssm():
+            ssm = boto3.client("ssm")
+            ssm.put_parameter(
+                Name=TEST_PUBLIC_KEY_SSM_PARAM_NAME,
+                Value=TEST_PUBLIC_KEY,
+                Type="SecureString",
+            )
+            yield
 
 
-def test_valid_pcse_token_return_allow_policy():
-    pass
+def test_valid_gp_token_return_allow_policy(mocker, mock_ssm_public_key, context):
+    decoded_token = {"user_role": "GP"}
+    decode_mock = mocker.patch("jwt.decode", return_value=decoded_token)
+    expected_allow_policy = {
+        "Statement": [
+            {
+                "Action": "execute-api:Invoke",
+                "Effect": "Allow",
+                "Resource": [f"{MOCK_METHOD_ARN_PREFIX}/*/*"],
+            }
+        ],
+        "Version": "2012-10-17",
+    }
 
-def test_invalid_token_return_deny_policy():
-    pass
+    test_event = {
+        "authorizationToken": "valid_gp_token",
+        "methodArn": f"{MOCK_METHOD_ARN_PREFIX}/GET/SearchPatient",
+    }
 
-def test_invalid_signature_return_deny_policy():
-    pass
+    response = lambda_handler(test_event, context)
+
+    decode_mock.assert_called_with(
+        "valid_gp_token", TEST_PUBLIC_KEY, algorithms=["RS256"]
+    )
+    assert response["policyDocument"] == expected_allow_policy
+
+
+def test_valid_pcse_token_return_allow_policy(mocker, mock_ssm_public_key, context):
+    decoded_token = {"user_role": "PCSE"}
+    decode_mock = mocker.patch("jwt.decode", return_value=decoded_token)
+    expected_allow_policy = {
+        "Statement": [
+            {
+                "Action": "execute-api:Invoke",
+                "Effect": "Allow",
+                "Resource": [f"{MOCK_METHOD_ARN_PREFIX}/GET/SearchDocumentReferences"],
+            }
+        ],
+        "Version": "2012-10-17",
+    }
+
+    test_event = {
+        "authorizationToken": "valid_pcse_token",
+        "methodArn": f"{MOCK_METHOD_ARN_PREFIX}/GET/SearchPatient",
+    }
+
+    response = lambda_handler(test_event, context)
+
+    decode_mock.assert_called_with(
+        "valid_pcse_token", TEST_PUBLIC_KEY, algorithms=["RS256"]
+    )
+    assert response["policyDocument"] == expected_allow_policy
+
+
+def test_invalid_token_return_deny_policy(mocker, mock_ssm_public_key, context):
+    decode_mock = mocker.patch(
+        "jwt.decode", side_effect=jwt.exceptions.InvalidTokenError
+    )
+
+    expected_deny_policy = {
+        "Statement": [
+            {
+                "Action": "execute-api:Invoke",
+                "Effect": "Deny",
+                "Resource": [f"{MOCK_METHOD_ARN_PREFIX}/*/*"],
+            }
+        ],
+        "Version": "2012-10-17",
+    }
+
+    test_event = {
+        "authorizationToken": "invalid_token",
+        "methodArn": f"{MOCK_METHOD_ARN_PREFIX}/GET/SearchPatient",
+    }
+    response = lambda_handler(test_event, context)
+
+    decode_mock.assert_called_with(
+        "invalid_token", TEST_PUBLIC_KEY, algorithms=["RS256"]
+    )
+    assert response["policyDocument"] == expected_deny_policy
+
+
+def test_invalid_signature_return_deny_policy(mocker, mock_ssm_public_key, context):
+    decode_mock = mocker.patch(
+        "jwt.decode", side_effect=jwt.exceptions.InvalidSignatureError
+    )
+
+    expected_deny_policy = {
+        "Statement": [
+            {
+                "Action": "execute-api:Invoke",
+                "Effect": "Deny",
+                "Resource": [f"{MOCK_METHOD_ARN_PREFIX}/*/*"],
+            }
+        ],
+        "Version": "2012-10-17",
+    }
+
+    test_event = {
+        "authorizationToken": "token_with_invalid_signature",
+        "methodArn": f"{MOCK_METHOD_ARN_PREFIX}/GET/SearchPatient",
+    }
+    response = lambda_handler(test_event, context)
+
+    decode_mock.assert_called_with(
+        "token_with_invalid_signature", TEST_PUBLIC_KEY, algorithms=["RS256"]
+    )
+
+    assert response["policyDocument"] == expected_deny_policy

--- a/lambdas/tests/unit/handlers/test_document_reference_search_handler.py
+++ b/lambdas/tests/unit/handlers/test_document_reference_search_handler.py
@@ -45,12 +45,17 @@ def test_lambda_handler_returns_items_from_both_tables_dynamo(event_valid_id, co
 
 def test_lambda_handler_returns_items_from_doc_store_only(event_valid_id, context):
     with patch.dict(os.environ, PATCH_ENV_VAR):
-        with patch.object(DynamoQueryService, "__call__", side_effect=[MOCK_RESPONSE, MOCK_EMPTY_RESPONSE]):
+        with patch.object(
+            DynamoQueryService,
+            "__call__",
+            side_effect=[MOCK_RESPONSE, MOCK_EMPTY_RESPONSE],
+        ):
             expected = ApiGatewayResponse(
                 200, json.dumps(EXPECTED_RESPONSE), "GET"
             ).create_api_gateway_response()
             actual = lambda_handler(event_valid_id, context)
             assert expected == actual
+
 
 def test_lambda_handler_returns_204_empty_list_when_dynamo_returns_no_records(
     event_valid_id, context


### PR DESCRIPTION
- Add an authoriser lambda which verify and decode a JWT authorizationToken, and respond with IAM policy which allow or deny user access to other APIs
- Add unit test for above lambda
- Change `make zip` command to pack with `--platform manylinux2014_x86_64` flag, as python's cryptography package seems to require some platform specific native library