### PR TITLE
hotfix for Runtime.ImportModuleError

### DIFF
--- a/lambdas/services/lloyd_george_validator.py
+++ b/lambdas/services/lloyd_george_validator.py
@@ -1,6 +1,6 @@
 import re
 
-from lambdas.models.nhs_document_reference import NHSDocumentReference
+from models.nhs_document_reference import NHSDocumentReference
 
 class LGInvalidFilesException(Exception):
     pass

--- a/lambdas/tests/unit/handlers/test_login_redirect_handler.py
+++ b/lambdas/tests/unit/handlers/test_login_redirect_handler.py
@@ -4,7 +4,7 @@ from oauthlib.oauth2 import InsecureTransportError
 from tests.unit.helpers.ssm_responses import \
     MOCK_MULTI_STRING_PARAMETERS_RESPONSE
 
-from lambdas.utils.lambda_response import ApiGatewayResponse
+from utils.lambda_response import ApiGatewayResponse
 
 RETURN_URL = (
     "https://www.string_value_1.com?"


### PR DESCRIPTION
hotfix to resolve a `Runtime.ImportModuleError` encountered in ndrb during testing
related log from cloudwatch:

![image](https://github.com/nhsconnect/national-document-repository/assets/127404525/95aea115-5010-4a87-a8f8-c8038c8f8731)
