### PR TITLE
Hotfix prmdr 338

### DIFF
--- a/lambdas/services/bulk_upload_service.py
+++ b/lambdas/services/bulk_upload_service.py
@@ -77,7 +77,7 @@ class BulkUploadService:
         file_names = [
             os.path.basename(metadata.file_path) for metadata in staging_metadata.files
         ]
-        validate_lg_file_names(file_names)
+        validate_lg_file_names(file_names, staging_metadata.nhs_number)
 
     def init_transaction(self):
         self.dynamo_records_in_transaction = []

--- a/lambdas/services/bulk_upload_service.py
+++ b/lambdas/services/bulk_upload_service.py
@@ -67,8 +67,8 @@ class BulkUploadService:
                 f"Successfully uploaded the Lloyd George records for patient: {staging_metadata.nhs_number}"
             )
         except Exception as e:
-            logger.debug(f"Got unexpected error during file transfer: {str(e)}")
-            logger.debug("Will try to rollback any change to database and bucket")
+            logger.info(f"Got unexpected error during file transfer: {str(e)}")
+            logger.info("Will try to rollback any change to database and bucket")
             self.rollback_transaction()
 
     def validate_files(self, staging_metadata: StagingMetadata):
@@ -100,7 +100,7 @@ class BulkUploadService:
     def create_record_in_lg_dynamo_table(
         self, document_reference: NHSDocumentReference
     ):
-        self.dynamo_service.post_item_service(
+        self.dynamo_service.create_item(
             table_name=self.lg_dynamo_table, item=document_reference.to_dict()
         )
         self.dynamo_records_in_transaction.append(document_reference)

--- a/lambdas/tests/unit/services/test_bulk_upload_service.py
+++ b/lambdas/tests/unit/services/test_bulk_upload_service.py
@@ -106,10 +106,10 @@ def test_create_lg_records_and_copy_files(set_env, mocker, mock_uuid):
         )
     assert service.s3_service.copy_across_bucket.call_count == 3
 
-    service.dynamo_service.post_item_service.assert_any_call(
+    service.dynamo_service.create_item.assert_any_call(
         table_name=MOCK_LG_TABLE_NAME, item=TEST_DOCUMENT_REFERENCE.to_dict()
     )
-    assert service.dynamo_service.post_item_service.call_count == 3
+    assert service.dynamo_service.create_item.call_count == 3
 
 
 def test_convert_to_document_reference(set_env, mock_uuid):


### PR DESCRIPTION
- accomodate to recent change in method name in DynamoService `post_item_service` --> `create_item`
- change log level `debug` --> `info` to allow better visibility of error during file copying
- fix a missing argument in method `validate_lg_file_names`