### PR TITLE
[HOTFIX] [PRMDR-445] 

### DIFF
--- a/lambdas/services/pds_api_service.py
+++ b/lambdas/services/pds_api_service.py
@@ -28,7 +28,8 @@ class PdsApiService(PatientSearch):
                 + int(access_token_response["issued_at"]) / 1000
             )
             time_safety_margin_seconds = 10
-            if time.time() - access_token_expiration > time_safety_margin_seconds:
+            remaining_time_before_expiration = access_token_expiration - time.time()
+            if remaining_time_before_expiration < time_safety_margin_seconds:
                 access_token = self.get_new_access_token()
 
             x_request_id = str(uuid.uuid4())

--- a/lambdas/tests/unit/services/test_pds_api_service.py
+++ b/lambdas/tests/unit/services/test_pds_api_service.py
@@ -331,6 +331,47 @@ def test_pds_request_refresh_token_if_already_expired(mocker):
     )
 
 
+def test_pds_request_refresh_token_if_already_expired_11_seconds_ago(mocker):
+    response = Response()
+    response.status_code = 200
+    response._content = json.dumps(PDS_PATIENT).encode("utf-8")
+
+    time_now = 1600000000
+    mocker.patch("time.time", return_value=time_now)
+    mock_response_token = mock_pds_token_response_issued_at(time_now - 599 - 11)
+    new_mock_access_token = "mock_access_token"
+
+    mock_api_request_parameters = (
+        "api.test/endpoint/",
+        json.dumps(mock_response_token),
+    )
+    nhs_number = "1111111111"
+    mock_url_endpoint = "api.test/endpoint/Patient/" + nhs_number
+    mock_authorization_header = {
+        "Authorization": f"Bearer {new_mock_access_token}",
+        "X-Request-ID": "123412342",
+    }
+
+    mock_get_parameters = mocker.patch(
+        "services.pds_api_service.PdsApiService.get_parameters_for_pds_api_request",
+        return_value=mock_api_request_parameters,
+    )
+    mock_new_access_token = mocker.patch(
+        "services.pds_api_service.PdsApiService.get_new_access_token",
+        return_value=new_mock_access_token,
+    )
+    mocker.patch("uuid.uuid4", return_value="123412342")
+    mock_post = mocker.patch("requests.get", return_value=response)
+
+    pds_service.pds_request(nhs_number="1111111111", retry_on_expired=True)
+
+    mock_get_parameters.assert_called_once()
+    mock_new_access_token.assert_called_once()
+    mock_post.assert_called_with(
+        url=mock_url_endpoint, headers=mock_authorization_header
+    )
+
+
 def test_pds_request_expired_token(mocker):
     response = Response()
     response.status_code = 200


### PR DESCRIPTION
 Fix incorrect logic in PDS service related token expiry time comparison, add unit test to verify new logic
 
 A quick look for how this PR will change the token refresh timing:
![Screenshot 2023-11-07 at 10 33 35](https://github.com/nhsconnect/national-document-repository/assets/127404525/2f05b16c-3a82-42d1-9fc4-4637521f9a6f)
