### PR TITLE
Fix back channel logout to handle logout_token as urlencoded format

### DIFF
--- a/lambdas/handlers/back_channel_logout_handler.py
+++ b/lambdas/handlers/back_channel_logout_handler.py
@@ -1,5 +1,5 @@
-import json
 import os
+from urllib.parse import parse_qs
 
 from botocore.exceptions import ClientError
 from enums.logging_app_interaction import LoggingAppInteraction
@@ -22,9 +22,14 @@ def lambda_handler(event, context):
 
     logger.info(f"incoming event {event}")
     try:
-        body = json.loads(event["body"])
-        token = body["logout_token"]
-    except KeyError as e:
+        body = parse_qs(event["body"])
+        token = body["logout_token"][0]
+    except (KeyError, IndexError) as e:
+        logger.error(e)
+        logger.error(
+            f"An error occurred due to missing key: {str(e)}",
+            {"Result": "Unsuccessful logout"},
+        )
         return ApiGatewayResponse(
             400, f"An error occurred due to missing key: {str(e)}", "POST"
         ).create_api_gateway_response()

--- a/lambdas/handlers/back_channel_logout_handler.py
+++ b/lambdas/handlers/back_channel_logout_handler.py
@@ -76,14 +76,10 @@ def remove_session_from_dynamo_db(sid):
         dynamodb_name, filter_expression=filter_sid
     )
 
-    logger.info(f'db response {db_response}')
     if "Items" in db_response:
         items = db_response["Items"]
-        
-        logger.info(f'item 0: {items[0]}')
         ndr_session_id = items[0]["NDRSessionId"]
-        logger.info(f'ndrSessionId: {ndr_session_id}')
-        
+
         dynamodb_service.delete_item(
             key={"NDRSessionId": ndr_session_id }, table_name=dynamodb_name
         )

--- a/lambdas/handlers/back_channel_logout_handler.py
+++ b/lambdas/handlers/back_channel_logout_handler.py
@@ -80,10 +80,12 @@ def remove_session_from_dynamo_db(sid):
     if "Items" in db_response:
         items = db_response["Items"]
         
-        while "NDRSessionId" in items:
-            logger.info(f'ndr session id {db_response["NDRSessionId"]}')
-            dynamodb_service.delete_item(
-                key={"NDRSessionId": db_response["NDRSessionId"]}, table_name=dynamodb_name
-            )
+        logger.info(f'item 0: {items[0]}')
+        ndr_session_id = items[0]["NDRSessionId"]
+        logger.info(f'ndrSessionId: {ndr_session_id}')
+        
+        dynamodb_service.delete_item(
+            key={"NDRSessionId": ndr_session_id }, table_name=dynamodb_name
+        )
 
-    logger.info(f"Session removed: {sid}", {"Result": "Successful logout"})
+    logger.info(f"Session removed for sid: {sid} and NDRSessionId {ndr_session_id }", {"Result": "Successful logout"})

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -20,12 +20,9 @@ def lambda_handler(event, context):
     token = None
     headers = event.get("headers")
     logger.info(f"Headers: {headers}")
-
-    headerDump = json.dump(headers);
-    logger.info(f"Headers dump: {headerDump}")
                 
     if headers:
-        token = json.dump(headers)["x-auth"]
+        token = headers["x-auth"]
         logger.info(f"Token found: {token}")
     return logout_handler(token)
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -18,7 +18,7 @@ def lambda_handler(event, context):
     request_context.app_interaction = LoggingAppInteraction.LOGOUT.value
     token = None
     if event.get("headers"):
-        token = str.encode(event.get("headers").get("Authorization"))
+        token = event.get("headers").get("Authorization")
     return logout_handler(token)
 
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -2,6 +2,7 @@ import os
 
 import boto3
 import jwt
+import json
 from botocore.exceptions import ClientError
 from enums.logging_app_interaction import LoggingAppInteraction
 from services.dynamo_service import DynamoDBService
@@ -19,8 +20,9 @@ def lambda_handler(event, context):
     token = None
     headers = event.get("headers")
     logger.info(f"Headers: {headers}")
+    logger.info(f"Headers dump": {json.dump(headers)})
     if headers:
-        token = headers.get("x-auth")
+        token = json.dump(headers)["x-auth"]
         logger.info(f"Token found: {token}")
     return logout_handler(token)
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -18,7 +18,7 @@ def lambda_handler(event, context):
     request_context.app_interaction = LoggingAppInteraction.LOGOUT.value
     token = None
     if event.get("headers"):
-        token = event.get("headers").get("Authorization")
+        token = str.encode(event.get("headers").get("X-Auth"))
     return logout_handler(token)
 
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -19,11 +19,8 @@ def lambda_handler(event, context):
     request_context.app_interaction = LoggingAppInteraction.LOGOUT.value
     token = None
     headers = event.get("headers")
-    logger.info(f"Headers: {headers}")
-                
     if headers:
         token = headers["x-auth"]
-        logger.info(f"Token found: {token}")
     return logout_handler(token)
 
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -18,7 +18,7 @@ def lambda_handler(event, context):
     request_context.app_interaction = LoggingAppInteraction.LOGOUT.value
     token = None
     if event.get("headers"):
-        token = str.encode(event.get("headers").get("X-Auth"))
+        token = event.get("headers").get("X-Auth")
     return logout_handler(token)
 
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -19,8 +19,8 @@ def lambda_handler(event, context):
     token = None
     headers = event.get("headers")
     logger.info(f"Headers: {headers}")
-    if event.get("headers"):
-        token = event.get("headers").get("X-Auth")
+    if headers:
+        token = headers.get("x-auth")
         logger.info(f"Token found: {token}")
     return logout_handler(token)
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -17,6 +17,8 @@ logger = LoggingService(__name__)
 def lambda_handler(event, context):
     request_context.app_interaction = LoggingAppInteraction.LOGOUT.value
     token = None
+    headers = event.get("headers")
+    logger.info(f"Headers: {headers}")
     if event.get("headers"):
         token = event.get("headers").get("X-Auth")
         logger.info(f"Token found: {token}")

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -19,6 +19,7 @@ def lambda_handler(event, context):
     token = None
     if event.get("headers"):
         token = event.get("headers").get("X-Auth")
+        logger.info(f"Token found: {token}")
     return logout_handler(token)
 
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -18,7 +18,7 @@ def lambda_handler(event, context):
     request_context.app_interaction = LoggingAppInteraction.LOGOUT.value
     token = None
     if event.get("headers"):
-        token = event.get("headers").get("Authorization")
+        token = str.encode(event.get("headers").get("Authorization"))
     return logout_handler(token)
 
 

--- a/lambdas/handlers/logout_handler.py
+++ b/lambdas/handlers/logout_handler.py
@@ -20,7 +20,10 @@ def lambda_handler(event, context):
     token = None
     headers = event.get("headers")
     logger.info(f"Headers: {headers}")
-    logger.info(f"Headers dump": {json.dump(headers)})
+
+    headerDump = json.dump(headers);
+    logger.info(f"Headers dump: {headerDump}")
+                
     if headers:
         token = json.dump(headers)["x-auth"]
         logger.info(f"Token found: {token}")

--- a/lambdas/tests/unit/handlers/test_back_channel_logout_handler.py
+++ b/lambdas/tests/unit/handlers/test_back_channel_logout_handler.py
@@ -1,4 +1,3 @@
-import json
 
 import pytest
 from botocore.exceptions import ClientError
@@ -130,5 +129,5 @@ def test_back_channel_logout_handler_boto_error_returns_500(
 
 
 def build_event_from_token(token: str) -> dict:
-    body_string = {"logout_token": token}
-    return {"httpMethod": "POST", "body": json.dumps(body_string)}
+    body_string = f"logout_token={token}"
+    return {"httpMethod": "POST", "body": body_string}


### PR DESCRIPTION
[CIS2 document](https://digital.nhs.uk/services/care-identity-service/applications-and-services/cis2-authentication/guidance-for-developers/detailed-guidance/session-management#back-channel-logout) mentioned the logout token is sent in a POST body by the application/x-www-form-urlencoded encoding, while our current implementation expects the POST body to be in json format.

This PR would allow extracting logout_token from urlencoded body.
