### PR TITLE
[PRMDR-657] fix styling so file name on design fits on single line

### DIFF
--- a/app/src/components/blocks/lloydGeorgeUploadComplete/LloydGeorgeUploadComplete.tsx
+++ b/app/src/components/blocks/lloydGeorgeUploadComplete/LloydGeorgeUploadComplete.tsx
@@ -61,7 +61,7 @@ function LloydGeorgeUploadComplete({ documents }: Props) {
                     You can upload more files to their record if needed, but you cannot upload
                     duplicate files with the same name as previous uploads.
                 </p>
-                <p>
+                <p style={{ marginBottom: 50 }}>
                     If you need to replace a file, you will need to remove it and re-upload it
                     again.
                 </p>

--- a/app/src/styles/App.scss
+++ b/app/src/styles/App.scss
@@ -309,7 +309,7 @@ $govuk-compatibility-govukelements: true;
         }
     }
     &_upload-complete {
-        max-width: 620px;
+        max-width: 660px;
         &_card {
             text-align: center;
             background-color: $color_nhsuk-blue;


### PR DESCRIPTION
When making recording, realised longer file names are put onto 2 lines so tweaked styling to fix