### PR TITLE
[PRMP-839] Fixed suspended patient is active logic & added unit test

### DIFF
--- a/lambdas/enums/patient_ods_inactive_status.py
+++ b/lambdas/enums/patient_ods_inactive_status.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 
 
 class PatientOdsInactiveStatus(StrEnum):
-    SUSPENDED = "SUSP",
+    SUSPENDED = "SUSP"
     DECEASED = "DECE"
 
     @staticmethod

--- a/lambdas/enums/patient_ods_inactive_status.py
+++ b/lambdas/enums/patient_ods_inactive_status.py
@@ -6,5 +6,5 @@ class PatientOdsInactiveStatus(StrEnum):
     DECEASED = "DECE"
 
     @staticmethod
-    def list():
+    def list() -> list[str]:
         return list(PatientOdsInactiveStatus.__members__.values())

--- a/lambdas/enums/patient_ods_inactive_status.py
+++ b/lambdas/enums/patient_ods_inactive_status.py
@@ -1,0 +1,10 @@
+from enum import StrEnum
+
+
+class PatientOdsInactiveStatus(StrEnum):
+    SUSPENDED = "SUSP",
+    DECEASED = "DECE"
+
+    @staticmethod
+    def list():
+        return list(PatientOdsInactiveStatus.__members__.values())

--- a/lambdas/models/pds_models.py
+++ b/lambdas/models/pds_models.py
@@ -4,7 +4,10 @@ from typing import Optional, Tuple
 from enums.death_notification_status import DeathNotificationStatus
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
+
+from enums.patient_ods_inactive_status import PatientOdsInactiveStatus
 from utils.audit_logging_setup import LoggingService
+from utils.ods_utils import is_ods_code_active
 
 logger = LoggingService(__name__)
 conf = ConfigDict(alias_generator=to_camel)
@@ -157,12 +160,14 @@ class Patient(BaseModel):
 
         death_notification_status = self.get_death_notification_status()
         if not is_deceased(death_notification_status) and self.is_unrestricted():
-            return "SUSP"
+            return PatientOdsInactiveStatus.SUSPENDED
         return ""
+
 
     def get_is_active_status(self) -> bool:
         gp_ods = self.get_active_ods_code_for_gp()
-        return not (gp_ods == "SUSP" or gp_ods == "")
+        return is_ods_code_active(gp_ods)
+
 
     def get_death_notification_status(self) -> Optional[DeathNotificationStatus]:
         if not self.deceased_date_time:

--- a/lambdas/models/pds_models.py
+++ b/lambdas/models/pds_models.py
@@ -162,7 +162,7 @@ class Patient(BaseModel):
 
     def get_is_active_status(self) -> bool:
         gp_ods = self.get_active_ods_code_for_gp()
-        return bool(gp_ods)
+        return not (gp_ods == "SUSP" or gp_ods == "")
 
     def get_death_notification_status(self) -> Optional[DeathNotificationStatus]:
         if not self.deceased_date_time:

--- a/lambdas/models/pds_models.py
+++ b/lambdas/models/pds_models.py
@@ -2,10 +2,9 @@ from datetime import date
 from typing import Optional, Tuple
 
 from enums.death_notification_status import DeathNotificationStatus
+from enums.patient_ods_inactive_status import PatientOdsInactiveStatus
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
-
-from enums.patient_ods_inactive_status import PatientOdsInactiveStatus
 from utils.audit_logging_setup import LoggingService
 from utils.ods_utils import is_ods_code_active
 
@@ -149,6 +148,13 @@ class Patient(BaseModel):
                 if entry.use.lower() == "home":
                     return entry
 
+    def get_ods_code_or_inactive_status_for_gp(self) -> str:
+        return (
+            self.get_active_ods_code_for_gp()
+            or self.get_status_for_inactive_patient()
+            or ""
+        )
+
     def get_active_ods_code_for_gp(self) -> str:
         for entry in self.general_practitioner:
             period = entry.identifier.period
@@ -158,16 +164,14 @@ class Patient(BaseModel):
             if not gp_end_date or gp_end_date >= date.today():
                 return entry.identifier.value
 
+    def get_status_for_inactive_patient(self) -> str:
         death_notification_status = self.get_death_notification_status()
         if not is_deceased(death_notification_status) and self.is_unrestricted():
             return PatientOdsInactiveStatus.SUSPENDED
-        return ""
-
 
     def get_is_active_status(self) -> bool:
-        gp_ods = self.get_active_ods_code_for_gp()
+        gp_ods = self.get_ods_code_or_inactive_status_for_gp()
         return is_ods_code_active(gp_ods)
-
 
     def get_death_notification_status(self) -> Optional[DeathNotificationStatus]:
         if not self.deceased_date_time:
@@ -216,7 +220,7 @@ class Patient(BaseModel):
             nhsNumber=self.id,
             superseded=bool(nhs_number == id),
             restricted=not self.is_unrestricted(),
-            generalPracticeOds=self.get_active_ods_code_for_gp(),
+            generalPracticeOds=self.get_ods_code_or_inactive_status_for_gp(),
             active=self.get_is_active_status(),
             deceased=is_deceased(death_notification_status),
             deathNotificationStatus=death_notification_status,
@@ -233,7 +237,9 @@ class Patient(BaseModel):
             familyName=family_name,
             birthDate=self.birth_date,
             generalPracticeOds=(
-                self.get_active_ods_code_for_gp() if self.is_unrestricted() else ""
+                self.get_ods_code_or_inactive_status_for_gp()
+                if self.is_unrestricted()
+                else ""
             ),
             nhsNumber=self.id,
             superseded=bool(nhs_number == id),

--- a/lambdas/services/search_patient_details_service.py
+++ b/lambdas/services/search_patient_details_service.py
@@ -11,6 +11,7 @@ from utils.exceptions import (
     UserNotAuthorisedException,
 )
 from utils.lambda_exceptions import SearchPatientException
+from utils.ods_utils import is_ods_code_active
 from utils.utilities import get_pds_service
 
 logger = LoggingService(__name__)
@@ -65,7 +66,7 @@ class SearchPatientDetailsService:
             raise SearchPatientException(400, LambdaError.SearchPatientNoParse)
 
     def check_if_user_authorise(self, gp_ods_for_patient):
-        patient_is_active = bool(gp_ods_for_patient)
+        patient_is_active = is_ods_code_active(gp_ods_for_patient)
         match self.user_role:
             case RepositoryRole.GP_ADMIN.value:
                 # Not raising error here if gp_ods is null / empty

--- a/lambdas/tests/unit/helpers/data/pds/pds_patient_response.py
+++ b/lambdas/tests/unit/helpers/data/pds/pds_patient_response.py
@@ -592,3 +592,6 @@ PDS_PATIENT_DECEASED_INFORMAL["extension"][-1]["extension"][0]["valueCodeableCon
     "display": "Informal - death notice received via an update from a local NHS "
     "Organisation such as GENERAL PRACTITIONER or NHS Trust",
 }
+
+PDS_PATIENT_SUSPENDED = copy.deepcopy(PDS_PATIENT)
+PDS_PATIENT_SUSPENDED["generalPractitioner"][0]["identifier"].pop("period")

--- a/lambdas/tests/unit/models/test_pds_models.py
+++ b/lambdas/tests/unit/models/test_pds_models.py
@@ -1,6 +1,7 @@
 import copy
 
 from enums.death_notification_status import DeathNotificationStatus
+from enums.patient_ods_inactive_status import PatientOdsInactiveStatus
 from freezegun import freeze_time
 from models.pds_models import PatientDetails
 from tests.unit.conftest import EXPECTED_PARSED_PATIENT_BASE_CASE
@@ -73,7 +74,7 @@ def test_get_suspended_patient_details():
         nhsNumber="9000000009",
         superseded=False,
         restricted=False,
-        generalPracticeOds="SUSP",
+        generalPracticeOds=PatientOdsInactiveStatus.SUSPENDED,
         active=False,
     )
 
@@ -121,7 +122,7 @@ def test_gp_ods_susp_when_gp_end_date_indicates_inactive():
 
     response = patient.get_minimum_patient_details(patient.id)
 
-    assert response.general_practice_ods == "SUSP"
+    assert response.general_practice_ods == PatientOdsInactiveStatus.SUSPENDED
 
 
 def test_not_raise_error_when_no_gp_in_response():
@@ -129,7 +130,7 @@ def test_not_raise_error_when_no_gp_in_response():
 
     response = patient.get_minimum_patient_details(patient.id)
 
-    assert response.general_practice_ods == "SUSP"
+    assert response.general_practice_ods == PatientOdsInactiveStatus.SUSPENDED
 
 
 @freeze_time("2021-12-31")

--- a/lambdas/tests/unit/models/test_pds_models.py
+++ b/lambdas/tests/unit/models/test_pds_models.py
@@ -16,6 +16,7 @@ from tests.unit.helpers.data.pds.pds_patient_response import (
     PDS_PATIENT_WITH_GP_END_DATE,
     PDS_PATIENT_WITHOUT_ACTIVE_GP,
     PDS_PATIENT_WITHOUT_ADDRESS,
+    PDS_PATIENT_SUSPENDED,
 )
 from tests.unit.helpers.data.pds.test_cases_for_date_logic import (
     build_test_name,
@@ -53,6 +54,25 @@ def test_get_restricted_patient_details():
         superseded=False,
         restricted=True,
         generalPracticeOds="",
+        active=False,
+    )
+
+    result = patient.get_patient_details(patient.id)
+
+    assert expected_patient_details == result
+
+def test_get_suspended_patient_details():
+    patient = create_patient(PDS_PATIENT_SUSPENDED)
+
+    expected_patient_details = PatientDetails(
+        givenName=["Jane"],
+        familyName="Smith",
+        birthDate="2010-10-22",
+        postalCode="LS1 6AE",
+        nhsNumber="9000000009",
+        superseded=False,
+        restricted=False,
+        generalPracticeOds="SUSP",
         active=False,
     )
 

--- a/lambdas/tests/unit/models/test_pds_models.py
+++ b/lambdas/tests/unit/models/test_pds_models.py
@@ -13,10 +13,10 @@ from tests.unit.helpers.data.pds.pds_patient_response import (
     PDS_PATIENT_NO_PERIOD_IN_GENERAL_PRACTITIONER_IDENTIFIER,
     PDS_PATIENT_NO_PERIOD_IN_NAME_MODEL,
     PDS_PATIENT_RESTRICTED,
+    PDS_PATIENT_SUSPENDED,
     PDS_PATIENT_WITH_GP_END_DATE,
     PDS_PATIENT_WITHOUT_ACTIVE_GP,
     PDS_PATIENT_WITHOUT_ADDRESS,
-    PDS_PATIENT_SUSPENDED,
 )
 from tests.unit.helpers.data.pds.test_cases_for_date_logic import (
     build_test_name,
@@ -60,6 +60,7 @@ def test_get_restricted_patient_details():
     result = patient.get_patient_details(patient.id)
 
     assert expected_patient_details == result
+
 
 def test_get_suspended_patient_details():
     patient = create_patient(PDS_PATIENT_SUSPENDED)

--- a/lambdas/tests/unit/services/test_search_patient_details_service.py
+++ b/lambdas/tests/unit/services/test_search_patient_details_service.py
@@ -9,6 +9,11 @@ from utils.exceptions import (
 )
 from utils.lambda_exceptions import SearchPatientException
 
+USER_VALID_ODS_CODE = "ABC123"
+PATIENT_VALID_ODS_CODE = "XYZ789"
+INVALID_ODS_CODE = "SOME_INVALID_ODS_CODE"
+EMPTY_ODS_CODE = ""
+
 
 @pytest.fixture(scope="function")
 def mock_service(request, mocker):
@@ -33,7 +38,11 @@ def mock_check_if_user_authorise(mocker, mock_service):
 
 @pytest.mark.parametrize(
     "mock_service",
-    (("GP_ADMIN", "test_ods_code"), ("GP_CLINICAL", "test_ods_code"), ("PCSE", "")),
+    (
+        ("GP_ADMIN", USER_VALID_ODS_CODE),
+        ("GP_CLINICAL", USER_VALID_ODS_CODE),
+        ("PCSE", ""),
+    ),
     indirect=True,
 )
 def test_check_if_user_authorise_valid(mock_service):
@@ -47,24 +56,26 @@ def test_check_if_user_authorise_valid(mock_service):
 @pytest.mark.parametrize(
     "mock_service",
     (
-        ("GP_ADMIN", "test_ods_code"),
-        ("GP_ADMIN", ""),
-        ("GP_CLINICAL", "test_ods_code"),
-        ("GP_CLINICAL", ""),
-        ("PCSE", ""),
-        ("PCSE", "new_gp_ods_code"),
-        ("Not_valid", "new_gp_ods_code"),
-        ("Not_valid", ""),
+        ("GP_ADMIN", USER_VALID_ODS_CODE),
+        ("GP_ADMIN", EMPTY_ODS_CODE),
+        ("GP_CLINICAL", USER_VALID_ODS_CODE),
+        ("GP_CLINICAL", EMPTY_ODS_CODE),
+        ("PCSE", EMPTY_ODS_CODE),
+        ("PCSE", PATIENT_VALID_ODS_CODE),
+        ("Not_valid", PATIENT_VALID_ODS_CODE),
+        ("Not_valid", EMPTY_ODS_CODE),
     ),
     indirect=True,
 )
 def test_check_if_user_authorise_raise_error(mock_service):
     with pytest.raises(UserNotAuthorisedException):
-        mock_service.check_if_user_authorise("new_gp_ods_code")
+        mock_service.check_if_user_authorise(PATIENT_VALID_ODS_CODE)
 
 
 @pytest.mark.parametrize(
-    "mock_service", (("GP_ADMIN", "test_ods_code"), ("GP_ADMIN", "")), indirect=True
+    "mock_service",
+    (("GP_ADMIN", USER_VALID_ODS_CODE), ("GP_ADMIN", EMPTY_ODS_CODE)),
+    indirect=True,
 )
 def test_handle_search_patient_request_valid(mock_service, mocker):
     pds_service_response = PatientDetails(
@@ -98,7 +109,9 @@ def test_handle_search_patient_request_valid(mock_service, mocker):
 
 
 @pytest.mark.parametrize(
-    "mock_service", (("GP_ADMIN", "test_ods_code"), ("GP_ADMIN", "")), indirect=True
+    "mock_service",
+    (("GP_ADMIN", USER_VALID_ODS_CODE), ("GP_ADMIN", EMPTY_ODS_CODE)),
+    indirect=True,
 )
 def test_handle_search_patient_request_raise_error_when_patient_not_found(
     mock_service, mock_pds_service_fetch
@@ -111,7 +124,9 @@ def test_handle_search_patient_request_raise_error_when_patient_not_found(
 
 
 @pytest.mark.parametrize(
-    "mock_service", (("GP_ADMIN", "test_ods_code"), ("GP_ADMIN", "")), indirect=True
+    "mock_service",
+    (("GP_ADMIN", USER_VALID_ODS_CODE), ("GP_ADMIN", EMPTY_ODS_CODE)),
+    indirect=True,
 )
 def test_handle_search_patient_request_raise_error_when_user_is_not_auth(
     mock_service, mock_pds_service_fetch, mock_check_if_user_authorise
@@ -125,7 +140,9 @@ def test_handle_search_patient_request_raise_error_when_user_is_not_auth(
 
 
 @pytest.mark.parametrize(
-    "mock_service", (("GP_ADMIN", "test_ods_code"), ("GP_ADMIN", "")), indirect=True
+    "mock_service",
+    (("GP_ADMIN", USER_VALID_ODS_CODE), ("GP_ADMIN", EMPTY_ODS_CODE)),
+    indirect=True,
 )
 def test_handle_search_patient_request_raise_error_when_invalid_patient(
     mock_service, mock_pds_service_fetch, mock_check_if_user_authorise
@@ -139,7 +156,9 @@ def test_handle_search_patient_request_raise_error_when_invalid_patient(
 
 
 @pytest.mark.parametrize(
-    "mock_service", (("GP_ADMIN", "test_ods_code"), ("GP_ADMIN", "")), indirect=True
+    "mock_service",
+    (("GP_ADMIN", USER_VALID_ODS_CODE), ("GP_ADMIN", EMPTY_ODS_CODE)),
+    indirect=True,
 )
 def test_handle_search_patient_request_raise_error_when_pds_error(
     mock_service, mock_pds_service_fetch, mock_check_if_user_authorise

--- a/lambdas/tests/unit/services/test_search_patient_details_service.py
+++ b/lambdas/tests/unit/services/test_search_patient_details_service.py
@@ -11,7 +11,6 @@ from utils.lambda_exceptions import SearchPatientException
 
 USER_VALID_ODS_CODE = "ABC123"
 PATIENT_VALID_ODS_CODE = "XYZ789"
-INVALID_ODS_CODE = "SOME_INVALID_ODS_CODE"
 EMPTY_ODS_CODE = ""
 
 

--- a/lambdas/tests/unit/utils/test_ods_utils.py
+++ b/lambdas/tests/unit/utils/test_ods_utils.py
@@ -1,5 +1,4 @@
 import pytest
-
 from enums.patient_ods_inactive_status import PatientOdsInactiveStatus
 from utils.ods_utils import is_ods_code_active
 
@@ -11,8 +10,8 @@ from utils.ods_utils import is_ods_code_active
         [PatientOdsInactiveStatus.SUSPENDED, False],
         [PatientOdsInactiveStatus.DECEASED, False],
         ["", False],
-        [None, False]
-    ]
+        [None, False],
+    ],
 )
 def test_is_ods_code_active(ods_code, expected):
     actual = is_ods_code_active(ods_code)

--- a/lambdas/tests/unit/utils/test_ods_utils.py
+++ b/lambdas/tests/unit/utils/test_ods_utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+from enums.patient_ods_inactive_status import PatientOdsInactiveStatus
+from utils.ods_utils import is_ods_code_active
+
+
+@pytest.mark.parametrize(
+    "ods_code,expected",
+    [
+        ["H81109", True],
+        [PatientOdsInactiveStatus.SUSPENDED, False],
+        [PatientOdsInactiveStatus.DECEASED, False],
+        ["", False],
+        [None, False]
+    ]
+)
+def test_is_ods_code_active(ods_code, expected):
+    actual = is_ods_code_active(ods_code)
+
+    assert actual == expected

--- a/lambdas/utils/ods_utils.py
+++ b/lambdas/utils/ods_utils.py
@@ -1,13 +1,16 @@
+from enums.patient_ods_inactive_status import PatientOdsInactiveStatus
+
 """
 On PDS, GP ODS codes must be 6 characters long, see the 'epraccur' document here for info:
 https://digital.nhs.uk/services/organisation-data-service/export-data-files/csv-downloads/gp-and-gp-practice-related-data
 
-Sometimes, a patient will not have a generalPractitioner on PDS. Internally, we can also add "SUSP", "DECE" codes to
-mark suspended and deceased patients for reporting purposes. The only values that should be considered 'active' is a
-valid ODS code.
+Sometimes, a patient will not have a generalPractitioner on PDS. Internally, we can also add codes to mark inactive
+patients for reporting purposes. The only values that should be considered 'active' are valid ODS codes.
 """
+
+
 def is_ods_code_active(gp_ods) -> bool:
     if gp_ods in PatientOdsInactiveStatus.list():
         return False
 
-    return len(gp_ods or '') == 6
+    return len(gp_ods or "") == 6

--- a/lambdas/utils/ods_utils.py
+++ b/lambdas/utils/ods_utils.py
@@ -1,0 +1,13 @@
+"""
+On PDS, GP ODS codes must be 6 characters long, see the 'epraccur' document here for info:
+https://digital.nhs.uk/services/organisation-data-service/export-data-files/csv-downloads/gp-and-gp-practice-related-data
+
+Sometimes, a patient will not have a generalPractitioner on PDS. Internally, we can also add "SUSP", "DECE" codes to
+mark suspended and deceased patients for reporting purposes. The only values that should be considered 'active' is a
+valid ODS code.
+"""
+def is_ods_code_active(gp_ods) -> bool:
+    if gp_ods in PatientOdsInactiveStatus.list():
+        return False
+
+    return len(gp_ods or '') == 6


### PR DESCRIPTION
Fixed bug where any truthy value for the ODS code would cause a patient to be flagged as active. This caused a problem where PCSE couldn't view suspended patients as their 'ODS code' was returning as `SUSP`, which is considered truthy and was incorrectly flagging them as active. 

Added a unit test with an example expected suspended patient response from PDS