### PR TITLE
[PRMP-1065] - Update ODS reports to contain total deceased

### DIFF
--- a/lambdas/services/bulk_upload_report_service.py
+++ b/lambdas/services/bulk_upload_report_service.py
@@ -89,6 +89,7 @@ class BulkUploadReportService:
             total_successful=ods_report.get_total_successful_count(),
             total_registered_elsewhere=ods_report.get_total_registered_elsewhere_count(),
             total_suspended=ods_report.get_total_suspended_count(),
+            total_deceased=ods_report.get_total_deceased_count(),
             extra_rows=ods_report.get_unsuccessful_reasons_data_rows(),
         )
 

--- a/lambdas/tests/unit/helpers/data/bulk_upload/expected_ods_report_for_uploader_1.csv
+++ b/lambdas/tests/unit/helpers/data/bulk_upload/expected_ods_report_for_uploader_1.csv
@@ -2,5 +2,6 @@ Type,Description,Count
 Total,Total Successful,5
 Total,Successful - Registered Elsewhere,1
 Total,Successful - Suspended,1
+Total,Successful - Deceased,1
 Reason,Could not find the given patient on PDS,2
 Reason,Lloyd George file already exists,1

--- a/lambdas/tests/unit/helpers/data/bulk_upload/expected_ods_report_for_uploader_2.csv
+++ b/lambdas/tests/unit/helpers/data/bulk_upload/expected_ods_report_for_uploader_2.csv
@@ -2,5 +2,6 @@ Type,Description,Count
 Total,Total Successful,5
 Total,Successful - Registered Elsewhere,1
 Total,Successful - Suspended,1
+Total,Successful - Deceased,1
 Reason,Could not find the given patient on PDS,2
 Reason,Lloyd George file already exists,1

--- a/lambdas/tests/unit/services/test_bulk_upload_report_service.py
+++ b/lambdas/tests/unit/services/test_bulk_upload_report_service.py
@@ -359,6 +359,7 @@ def test_generate_individual_ods_report_creates_ods_report(
         total_successful=5,
         total_registered_elsewhere=1,
         total_suspended=1,
+        total_deceased=1,
         extra_rows=[
             ["Reason", "Could not find the given patient on PDS", 2],
             ["Reason", "Lloyd George file already exists", 1],


### PR DESCRIPTION
The "Successful - Deceased" should also be added to the per ODS summary reports, so we can determine a count for all deceased patients uploaded by that ODS code.