### PR TITLE
[PRM-64] WCAG 3.3.2: missing labels on download checkboxes

### DIFF
--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.test.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.test.tsx
@@ -87,7 +87,9 @@ describe('LloydGeorgeSelectSearchResults', () => {
             renderComponent({ selectedDocuments: mockSelectedDocuments });
             const expectedSelectedDocument = [...mockSelectedDocuments, searchResults[2].ID];
 
-            const checkbox = screen.getByRole('checkbox', { name: searchResults[2].fileName });
+            const checkbox = screen.getByRole('checkbox', {
+                name: `Select Filename ${searchResults[2].fileName}`,
+            });
             expect(checkbox).not.toBeChecked();
 
             act(() => {
@@ -102,7 +104,9 @@ describe('LloydGeorgeSelectSearchResults', () => {
                 (id) => id !== searchResults[0].ID,
             );
 
-            const checkbox = screen.getByRole('checkbox', { name: searchResults[0].fileName });
+            const checkbox = screen.getByRole('checkbox', {
+                name: `Select Filename ${searchResults[0].fileName}`,
+            });
             expect(checkbox).toBeChecked();
 
             act(() => {

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.test.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.test.tsx
@@ -60,7 +60,7 @@ describe('LloydGeorgeSelectSearchResults', () => {
             renderComponent({ selectedDocuments: mockSelectedDocuments });
 
             const headers = screen.getAllByRole('columnheader');
-            const expectedHeaders = ['Selected', 'Filename', 'Upload date', 'File size'];
+            const expectedHeaders = ['Selected', 'Upload date', 'File size'];
 
             expectedHeaders.forEach((headerText, index) => {
                 expect(headers[index]).toHaveTextContent(headerText);

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.tsx
@@ -110,8 +110,8 @@ const AvailableFilesTable = ({
                         {allowSelectDocument && (
                             <Table.Cell className={'table-column-header'}>Selected</Table.Cell>
                         )}
-                        <Table.Cell className={'table-column-header'}>
-                            Filename aria-hidden
+                        <Table.Cell className={'table-column-header'} aria-hidden>
+                            Filename
                         </Table.Cell>
                         <Table.Cell className={'table-column-header'}>Upload date</Table.Cell>
                         <Table.Cell className={'table-column-header'}>File size</Table.Cell>
@@ -131,7 +131,6 @@ const AvailableFilesTable = ({
                                         value={result.id}
                                         id={result.id}
                                         data-testid={`checkbox-${index}`}
-
                                         checked={selectedDocuments.includes(result.id)}
                                         aria-checked={selectedDocuments.includes(result.id)}
                                         aria-label={`Select Filename ${result.fileName}`}

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.tsx
@@ -107,7 +107,9 @@ const AvailableFilesTable = ({
                         {allowSelectDocument && (
                             <Table.Cell className={'table-column-header'}>Selected</Table.Cell>
                         )}
-                        <Table.Cell className={'table-column-header'}>Filename</Table.Cell>
+                        <Table.Cell className={'table-column-header'}>
+                            Filename aria-hidden
+                        </Table.Cell>
                         <Table.Cell className={'table-column-header'}>Upload date</Table.Cell>
                         <Table.Cell className={'table-column-header'}>File size</Table.Cell>
                     </Table.Row>

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeSelectSearchResults/LloydGeorgeSelectSearchResults.tsx
@@ -128,9 +128,10 @@ const AvailableFilesTable = ({
                                         data-testid={`checkbox-${index}`}
                                         checked={selectedDocuments.includes(result.ID)}
                                         aria-checked={selectedDocuments.includes(result.ID)}
+                                        aria-label={`Select Filename ${result.fileName}`}
                                         onChange={(e) => handleChangeCheckboxes(e)}
                                     >
-                                        <span className="nhsuk-u-visually-hidden">
+                                        <span className="nhsuk-u-visually-hidden" aria-hidden>
                                             {result.fileName}
                                         </span>
                                     </Checkboxes.Box>
@@ -139,6 +140,7 @@ const AvailableFilesTable = ({
                             <Table.Cell
                                 id={'available-files-row-' + index + '-filename'}
                                 data-testid="filename"
+                                aria-hidden
                             >
                                 {result.fileName}
                             </Table.Cell>


### PR DESCRIPTION
Adjusts how table is read out so that columns don't have mismatched headers