### PR TITLE
[PRM-299] Update Node.js from v18.x to v24.x

### DIFF
--- a/.github/workflows/base-vitest-test.yml
+++ b/.github/workflows/base-vitest-test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Configure React environment vars
         env:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Our React User Interface readme can be found [here](app/README.md)
 - [AWS CLI](https://aws.amazon.com/cli/)
 - [Awsume](https://formulae.brew.sh/formula/awsume)
 - [ruff](https://formulae.brew.sh/formula/ruff)
-- [Node@18](https://formulae.brew.sh/formula/node@18)
+- [Node@24](https://formulae.brew.sh/formula/node@24)
 - [Python@3.11](https://formulae.brew.sh/formula/python@3.11)
 
 _Note: It is recommended to use [Homebrew](https://brew.sh/) to install most of these._

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,5 @@
 # Build the App
-FROM node:18-alpine as builder
+FROM node:24-alpine as builder
 RUN apk add unzip wget
 WORKDIR /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,5 @@
 # Build the App
-FROM node:24-alpine as builder
+FROM node:24-alpine AS builder
 RUN apk add unzip wget
 WORKDIR /app
 

--- a/app/README.md
+++ b/app/README.md
@@ -14,7 +14,7 @@ The National Document Repository user interface (UI) has been developed with Rea
 
 ### Requirements
 
--   Node: Version 24.1.0
+-   Node: Version 24.x
 -   NPM: this should come installed with Node but if not version 11.4.1 or greater is recommended.
 -   Browser: Of your choice, although Chrome has better development tools.
 

--- a/app/README.md
+++ b/app/README.md
@@ -14,8 +14,8 @@ The National Document Repository user interface (UI) has been developed with Rea
 
 ### Requirements
 
--   Node: Version 18.0
--   NPM: this should come installed with Node but if not version 8.3.1 or greater is recommended.
+-   Node: Version 24.1.0
+-   NPM: this should come installed with Node but if not version 11.4.1 or greater is recommended.
 -   Browser: Of your choice, although Chrome has better development tools.
 
 ## Setup

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -54,7 +54,7 @@
             "devDependencies": {
                 "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
                 "@types/jest-axe": "^3.5.9",
-                "@types/node": "^16.18.40",
+                "@types/node": "^22.15.24",
                 "@types/react": "^18.2.19",
                 "@types/react-dom": "^18.2.7",
                 "@types/react-toggle": "^4.0.5",
@@ -4335,10 +4335,14 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.18.60",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.60.tgz",
-            "integrity": "sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==",
-            "dev": true
+            "version": "22.15.24",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.24.tgz",
+            "integrity": "sha512-w9CZGm9RDjzTh/D+hFwlBJ3ziUaVw7oufKA3vOFSOZlzmW9AkZnfjPb+DLnrV6qtgL/LNmP0/2zBNCFHL3F0ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
@@ -14267,6 +14271,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -66,7 +66,7 @@
     "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@types/jest-axe": "^3.5.9",
-        "@types/node": "^16.18.40",
+        "@types/node": "^22.15.24",
         "@types/react": "^18.2.19",
         "@types/react-dom": "^18.2.7",
         "@types/react-toggle": "^4.0.5",

--- a/app/package.json
+++ b/app/package.json
@@ -31,8 +31,6 @@
         "aws-sdk": "^2.1510.0",
         "axios": "^1.8.2",
         "dotenv": "^16.3.1",
-        "eslint-config-react-app": "^7.0.1",
-        "eslint-plugin-legacy-decorators": "^1.0.0",
         "fake-progress": "^1.0.4",
         "govuk-frontend": "^4.9.0",
         "history": "^5.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,7 @@
         "aws-sdk": "^2.1510.0",
         "axios": "^1.8.2",
         "dotenv": "^16.3.1",
+        "eslint-config-react-app": "^7.0.1",
         "fake-progress": "^1.0.4",
         "govuk-frontend": "^4.9.0",
         "history": "^5.3.0",


### PR DESCRIPTION
Jira ticket - https://nhsd-jira.digital.nhs.uk/browse/PRM-299

The version of "@types/node" is 22 as this is the latest version available! It is compatible with Node 24.