### PR TITLE
[PRME-115] Patient Summary Changes

### DIFF
--- a/app/cypress/e2e/0-ndr-core-tests/gp_user_workflows/view_lloyd_george_workflow.cy.js
+++ b/app/cypress/e2e/0-ndr-core-tests/gp_user_workflows/view_lloyd_george_workflow.cy.js
@@ -43,12 +43,12 @@ describe('GP Workflow: View Lloyd George record', () => {
     };
 
     const assertPatientInfo = () => {
-        cy.getByTestId('patient-name').should(
+        cy.getByTestId('patient-summary-full-name').should(
             'have.text',
-            `${searchPatientPayload.givenName}, ${searchPatientPayload.familyName}`,
+            `${searchPatientPayload.familyName}, ${searchPatientPayload.givenName}`,
         );
-        cy.getByTestId('patient-nhs-number').should('have.text', `NHS number: 900 000 0009`);
-        cy.getByTestId('patient-dob').should('have.text', `Date of birth: 01 January 1970`);
+        cy.getByTestId('patient-summary-nhs-number').should('have.text', `900 000 0009`);
+        cy.getByTestId('patient-summary-date-of-birth').should('have.text', `01 January 1970`);
     };
 
     const beforeEachConfiguration = (role) => {
@@ -263,8 +263,8 @@ describe('GP Workflow: View Lloyd George record', () => {
                 cy.getByTestId('remove-btn').click();
                 cy.contains('Surname').should('be.visible');
                 cy.contains('GivenName').should('be.visible');
-                cy.contains('NHS number: 900 000 0009').should('be.visible');
-                cy.contains('Date of birth: 01 January 1970').should('be.visible');
+                cy.contains('900 000 0009').should('be.visible');
+                cy.contains('01 January 1970').should('be.visible');
 
                 cy.intercept(
                     'DELETE',

--- a/app/src/components/blocks/_arf/selectStage/SelectStage.test.tsx
+++ b/app/src/components/blocks/_arf/selectStage/SelectStage.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../types/pages/UploadDocumentsPage/types';
 import { PatientDetails } from '../../../../types/generic/patientDetails';
 import usePatient from '../../../../helpers/hooks/usePatient';
+import { formatNhsNumber } from '../../../../helpers/utils/formatNhsNumber';
 import { useState } from 'react';
 import { runAxeTest } from '../../../../helpers/test/axeTestHelper';
 import { afterEach, beforeEach, describe, expect, it, vi, Mock } from 'vitest';
@@ -53,7 +54,8 @@ describe('<SelectStage />', () => {
             renderApp();
 
             expect(screen.getByRole('heading', { name: 'Upload documents' })).toBeInTheDocument();
-            expect(screen.getByText(mockPatientDetails.nhsNumber)).toBeInTheDocument();
+            const expectedNhsNumber = formatNhsNumber(mockPatientDetails.nhsNumber);
+            expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
             expect(screen.getByText('Select file(s)')).toBeInTheDocument();
 
             expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument();

--- a/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.test.tsx
+++ b/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.test.tsx
@@ -292,6 +292,13 @@ describe('DeleteSubmitStage', () => {
             const expectedDob = getFormattedDate(new Date(mockPatientDetails.birthDate));
             expect(screen.getByText(expectedDob)).toBeInTheDocument();
         });
+
+        it('shows deceased tag for deceased patients', async () => {
+            mockedUsePatient.mockReturnValue(buildPatientDetails({ deceased: true }));
+            renderComponent(DOCUMENT_TYPE.LLOYD_GEORGE, history);
+
+            expect(screen.getByTestId('deceased-patient-tag')).toBeInTheDocument();
+        });
     });
 
     describe('Accessibility', () => {

--- a/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.test.tsx
+++ b/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.test.tsx
@@ -14,6 +14,7 @@ import { MemoryHistory, createMemoryHistory } from 'history';
 import * as ReactRouter from 'react-router-dom';
 import waitForSeconds from '../../../../helpers/utils/waitForSeconds';
 import { afterEach, beforeEach, describe, expect, it, vi, Mock, Mocked } from 'vitest';
+import { formatNhsNumber } from '../../../../helpers/utils/formatNhsNumber';
 
 vi.mock('../../../../helpers/hooks/useConfig');
 vi.mock('../../../../helpers/hooks/useBaseAPIHeaders');
@@ -52,7 +53,6 @@ describe('DeleteSubmitStage', () => {
             initialEntries: ['/'],
             initialIndex: 0,
         });
-
         import.meta.env.VITE_ENVIRONMENT = 'vitest';
         mockedUsePatient.mockReturnValue(mockPatientDetails);
     });
@@ -65,7 +65,7 @@ describe('DeleteSubmitStage', () => {
         it.each(authorisedRoles)(
             "renders the page with patient details when user role is '%s'",
             async (role) => {
-                const patientName = `${mockPatientDetails.givenName}, ${mockPatientDetails.familyName}`;
+                const patientName = `${mockPatientDetails.familyName}, ${mockPatientDetails.givenName}`;
                 const dob = getFormattedDate(new Date(mockPatientDetails.birthDate));
                 mockedUseRole.mockReturnValue(role);
 
@@ -80,7 +80,7 @@ describe('DeleteSubmitStage', () => {
                 });
 
                 expect(screen.getByText(patientName)).toBeInTheDocument();
-                expect(screen.getByText(`Date of birth: ${dob}`)).toBeInTheDocument();
+                expect(screen.getByText(dob)).toBeInTheDocument();
                 expect(screen.getByText(/NHS number/)).toBeInTheDocument();
                 const yesButton = screen.getByRole('radio', { name: 'Yes' });
                 expect(yesButton).toBeInTheDocument();
@@ -275,6 +275,22 @@ describe('DeleteSubmitStage', () => {
             await waitFor(() => {
                 expect(screen.getByTestId('delete-submit-spinner-btn')).toBeInTheDocument();
             });
+        });
+
+        it('renders patient summary fields', async () => {
+            renderComponent(DOCUMENT_TYPE.LLOYD_GEORGE, history);
+
+            const expectedFullName = `${mockPatientDetails.familyName}, ${mockPatientDetails.givenName}`;
+            expect(screen.getByText(/Patient name/i)).toBeInTheDocument();
+            expect(screen.getByText(expectedFullName)).toBeInTheDocument();
+
+            expect(screen.getByText(/NHS number/i)).toBeInTheDocument();
+            const expectedNhsNumber = formatNhsNumber(mockPatientDetails.nhsNumber);
+            expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
+
+            expect(screen.getByText(/Date of birth/i)).toBeInTheDocument();
+            const expectedDob = getFormattedDate(new Date(mockPatientDetails.birthDate));
+            expect(screen.getByText(expectedDob)).toBeInTheDocument();
         });
     });
 

--- a/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.tsx
+++ b/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.tsx
@@ -22,10 +22,10 @@ import { isMock } from '../../../../helpers/utils/isLocal';
 import useConfig from '../../../../helpers/hooks/useConfig';
 import useTitle from '../../../../helpers/hooks/useTitle';
 import ErrorBox from '../../../layout/errorBox/ErrorBox';
-import PatientSimpleSummary from '../../../generic/patientSimpleSummary/PatientSimpleSummary';
 import { getLastURLPath } from '../../../../helpers/utils/urlManipulations';
 import DeleteResultStage from '../deleteResultStage/DeleteResultStage';
 import BackButton from '../../../generic/backButton/BackButton';
+import PatientSummary from '../../../generic/patientSummary/PatientSummary';
 
 export type Props = {
     docType: DOCUMENT_TYPE;
@@ -144,7 +144,11 @@ const DeleteSubmitStageIndexView = ({ docType, recordType, resetDocState }: Inde
             <form onSubmit={handleSubmit(submit)}>
                 <Fieldset id="radio-selection">
                     <Fieldset.Legend isPageHeading>{pageTitle}:</Fieldset.Legend>
-                    <PatientSimpleSummary separator showDeceasedTag />
+                    <PatientSummary>
+                        <PatientSummary.PatientFullName />
+                        <PatientSummary.PatientNhsNumber />
+                        <PatientSummary.PatientDob />
+                    </PatientSummary>
 
                     {!userIsGP && (
                         <WarningCallout>

--- a/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.tsx
+++ b/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.tsx
@@ -144,7 +144,7 @@ const DeleteSubmitStageIndexView = ({ docType, recordType, resetDocState }: Inde
             <form onSubmit={handleSubmit(submit)}>
                 <Fieldset id="radio-selection">
                     <Fieldset.Legend isPageHeading>{pageTitle}:</Fieldset.Legend>
-                    <PatientSummary>
+                    <PatientSummary showDeceasedTag>
                         <PatientSummary.PatientFullName />
                         <PatientSummary.PatientNhsNumber />
                         <PatientSummary.PatientDob />

--- a/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.tsx
+++ b/app/src/components/blocks/_delete/deleteSubmitStage/DeleteSubmitStage.tsx
@@ -25,7 +25,7 @@ import ErrorBox from '../../../layout/errorBox/ErrorBox';
 import { getLastURLPath } from '../../../../helpers/utils/urlManipulations';
 import DeleteResultStage from '../deleteResultStage/DeleteResultStage';
 import BackButton from '../../../generic/backButton/BackButton';
-import PatientSummary from '../../../generic/patientSummary/PatientSummary';
+import PatientSummary, { PatientInfo } from '../../../generic/patientSummary/PatientSummary';
 
 export type Props = {
     docType: DOCUMENT_TYPE;
@@ -145,9 +145,9 @@ const DeleteSubmitStageIndexView = ({ docType, recordType, resetDocState }: Inde
                 <Fieldset id="radio-selection">
                     <Fieldset.Legend isPageHeading>{pageTitle}:</Fieldset.Legend>
                     <PatientSummary showDeceasedTag>
-                        <PatientSummary.PatientFullName />
-                        <PatientSummary.PatientNhsNumber />
-                        <PatientSummary.PatientDob />
+                        <PatientSummary.Child item={PatientInfo.FULL_NAME} />
+                        <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
+                        <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
                     </PatientSummary>
 
                     {!userIsGP && (

--- a/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.test.tsx
+++ b/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.test.tsx
@@ -5,7 +5,6 @@ import {
     DOCUMENT_UPLOAD_STATE,
     UploadDocument,
 } from '../../../../types/pages/UploadDocumentsPage/types';
-import DocumentSelectStage from '../documentSelectStage/DocumentSelectStage';
 import { buildPatientDetails } from '../../../../helpers/test/testBuilders';
 import usePatient from '../../../../helpers/hooks/usePatient';
 import { getFormattedDate } from '../../../../helpers/utils/formatDate';
@@ -78,10 +77,10 @@ describe('DocumentSelectOrderStage', () => {
 
 function renderSut(documents: UploadDocument[]) {
     render(
-        <DocumentSelectStage
+        <DocumentSelectOrderStage
             documents={documents}
             setDocuments={() => {}}
-            documentType={DOCUMENT_TYPE.LLOYD_GEORGE}
+            setMergedPdfBlob={() => {}}
         />,
     );
 }

--- a/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.test.tsx
+++ b/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.test.tsx
@@ -5,6 +5,11 @@ import {
     DOCUMENT_UPLOAD_STATE,
     UploadDocument,
 } from '../../../../types/pages/UploadDocumentsPage/types';
+import DocumentSelectStage from '../documentSelectStage/DocumentSelectStage';
+import { buildPatientDetails } from '../../../../helpers/test/testBuilders';
+import usePatient from '../../../../helpers/hooks/usePatient';
+import { getFormattedDate } from '../../../../helpers/utils/formatDate';
+import { formatNhsNumber } from '../../../../helpers/utils/formatNhsNumber';
 
 const mockNavigate = vi.fn();
 vi.mock('../../../../helpers/hooks/usePatient');
@@ -12,11 +17,15 @@ vi.mock('react-router-dom', () => ({
     useNavigate: () => mockNavigate,
 }));
 
+const patientDetails = buildPatientDetails();
+
 URL.createObjectURL = vi.fn();
 
 describe('DocumentSelectOrderStage', () => {
     let documents: UploadDocument[] = [];
     beforeEach(() => {
+        vi.mocked(usePatient).mockReturnValue(patientDetails);
+
         import.meta.env.VITE_ENVIRONMENT = 'vitest';
         documents = [
             {
@@ -28,19 +37,14 @@ describe('DocumentSelectOrderStage', () => {
             },
         ];
     });
+
     afterEach(() => {
         vi.clearAllMocks();
     });
 
     describe('Rendering', () => {
         it('renders', async () => {
-            render(
-                <DocumentSelectOrderStage
-                    documents={documents}
-                    setDocuments={() => {}}
-                    setMergedPdfBlob={() => {}}
-                />,
-            );
+            renderSut(documents);
 
             await waitFor(async () => {
                 expect(
@@ -49,4 +53,35 @@ describe('DocumentSelectOrderStage', () => {
             });
         });
     });
+
+    it('renders patient summary fields is inset', async () => {
+        renderSut(documents);
+
+        const insetText = screen
+            .getByText('Make sure that all files uploaded are for this patient only:')
+            .closest('.nhsuk-inset-text');
+        expect(insetText).toBeInTheDocument();
+
+        const expectedFullName = `${patientDetails.familyName}, ${patientDetails.givenName}`;
+        expect(screen.getByText(/Patient name/i)).toBeInTheDocument();
+        expect(screen.getByText(expectedFullName)).toBeInTheDocument();
+
+        expect(screen.getByText(/NHS number/i)).toBeInTheDocument();
+        const expectedNhsNumber = formatNhsNumber(patientDetails.nhsNumber);
+        expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
+
+        expect(screen.getByText(/Date of birth/i)).toBeInTheDocument();
+        const expectedDob = getFormattedDate(new Date(patientDetails.birthDate));
+        expect(screen.getByText(expectedDob)).toBeInTheDocument();
+    });
 });
+
+function renderSut(documents: UploadDocument[]) {
+    render(
+        <DocumentSelectStage
+            documents={documents}
+            setDocuments={() => {}}
+            documentType={DOCUMENT_TYPE.LLOYD_GEORGE}
+        />,
+    );
+}

--- a/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.tsx
+++ b/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.tsx
@@ -5,7 +5,6 @@ import {
     SetUploadDocuments,
     UploadDocument,
 } from '../../../../types/pages/UploadDocumentsPage/types';
-import PatientSimpleSummary from '../../../generic/patientSimpleSummary/PatientSimpleSummary';
 import LinkButton from '../../../generic/linkButton/LinkButton';
 import { FieldValues, useForm } from 'react-hook-form';
 import { SelectRef } from '../../../../types/generic/selectRef';
@@ -16,6 +15,7 @@ import ErrorBox from '../../../layout/errorBox/ErrorBox';
 import { routeChildren, routes } from '../../../../types/generic/routes';
 import DocumentUploadLloydGeorgePreview from '../documentUploadLloydGeorgePreview/DocumentUploadLloydGeorgePreview';
 import React from 'react';
+import PatientSummary from '../../../generic/patientSummary/PatientSummary';
 
 type Props = {
     documents: UploadDocument[];
@@ -165,7 +165,15 @@ const DocumentSelectOrderStage = ({ documents, setDocuments, setMergedPdfBlob }:
         <>
             <BackButton />
             <h1>{pageTitle}</h1>
-            <PatientSimpleSummary />
+
+            <div className="nhsuk-inset-text">
+                <p>Make sure that all files uploaded are for this patient only:</p>
+                <PatientSummary>
+                    <PatientSummary.PatientFullName />
+                    <PatientSummary.PatientNhsNumber />
+                    <PatientSummary.PatientDob />
+                </PatientSummary>
+            </div>
 
             {errorMessage && (
                 <ErrorBox

--- a/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.tsx
+++ b/app/src/components/blocks/_documentUpload/documentSelectOrderStage/DocumentSelectOrderStage.tsx
@@ -15,7 +15,7 @@ import ErrorBox from '../../../layout/errorBox/ErrorBox';
 import { routeChildren, routes } from '../../../../types/generic/routes';
 import DocumentUploadLloydGeorgePreview from '../documentUploadLloydGeorgePreview/DocumentUploadLloydGeorgePreview';
 import React from 'react';
-import PatientSummary from '../../../generic/patientSummary/PatientSummary';
+import PatientSummary, { PatientInfo } from '../../../generic/patientSummary/PatientSummary';
 
 type Props = {
     documents: UploadDocument[];
@@ -169,9 +169,9 @@ const DocumentSelectOrderStage = ({ documents, setDocuments, setMergedPdfBlob }:
             <div className="nhsuk-inset-text">
                 <p>Make sure that all files uploaded are for this patient only:</p>
                 <PatientSummary>
-                    <PatientSummary.PatientFullName />
-                    <PatientSummary.PatientNhsNumber />
-                    <PatientSummary.PatientDob />
+                    <PatientSummary.Child item={PatientInfo.FULL_NAME} />
+                    <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
+                    <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
                 </PatientSummary>
             </div>
 

--- a/app/src/components/blocks/_documentUpload/documentSelectStage/DocumentSelectStage.test.tsx
+++ b/app/src/components/blocks/_documentUpload/documentSelectStage/DocumentSelectStage.test.tsx
@@ -9,6 +9,10 @@ import { useState } from 'react';
 import * as ReactRouter from 'react-router-dom';
 import { MemoryHistory, createMemoryHistory } from 'history';
 import { routeChildren } from '../../../../types/generic/routes';
+import { buildPatientDetails } from '../../../../helpers/test/testBuilders';
+import usePatient from '../../../../helpers/hooks/usePatient';
+import { formatNhsNumber } from '../../../../helpers/utils/formatNhsNumber';
+import { getFormattedDate } from '../../../../helpers/utils/formatDate';
 
 vi.mock('../../../../helpers/hooks/usePatient');
 vi.mock('react-router-dom', async () => {
@@ -21,6 +25,8 @@ vi.mock('react-router-dom', async () => {
 });
 vi.mock('pdfjs-dist');
 
+const patientDetails = buildPatientDetails();
+
 URL.createObjectURL = vi.fn();
 const mockedUseNavigate = vi.fn();
 
@@ -31,6 +37,8 @@ let history = createMemoryHistory({
 
 describe('DocumentSelectStage', () => {
     beforeEach(() => {
+        vi.mocked(usePatient).mockReturnValue(patientDetails);
+
         import.meta.env.VITE_ENVIRONMENT = 'vitest';
         history = createMemoryHistory({ initialEntries: ['/'], initialIndex: 0 });
     });
@@ -107,6 +115,31 @@ describe('DocumentSelectStage', () => {
                 expect(screen.getByText(lgDocumentOne.name)).toBeInTheDocument();
                 expect(screen.queryByText(lgDocumentTwo.name)).not.toBeInTheDocument();
             });
+
+            expect(
+                screen.getByRole('heading', { level: 2, name: 'Before you upload' }),
+            ).toBeInTheDocument();
+        });
+
+        it('renders patient summary fields is inset', async () => {
+            renderApp(history);
+
+            const insetText = screen
+                .getByText('Make sure that all files uploaded are for this patient only:')
+                .closest('.nhsuk-inset-text');
+            expect(insetText).toBeInTheDocument();
+
+            const expectedFullName = `${patientDetails.familyName}, ${patientDetails.givenName}`;
+            expect(screen.getByText(/Patient name/i)).toBeInTheDocument();
+            expect(screen.getByText(expectedFullName)).toBeInTheDocument();
+
+            expect(screen.getByText(/NHS number/i)).toBeInTheDocument();
+            const expectedNhsNumber = formatNhsNumber(patientDetails.nhsNumber);
+            expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
+
+            expect(screen.getByText(/Date of birth/i)).toBeInTheDocument();
+            const expectedDob = getFormattedDate(new Date(patientDetails.birthDate));
+            expect(screen.getByText(expectedDob)).toBeInTheDocument();
         });
     });
 

--- a/app/src/components/blocks/_documentUpload/documentSelectStage/DocumentSelectStage.tsx
+++ b/app/src/components/blocks/_documentUpload/documentSelectStage/DocumentSelectStage.tsx
@@ -15,7 +15,7 @@ import { Button, Fieldset, Table, TextInput } from 'nhsuk-react-components';
 import formatFileSize from '../../../../helpers/utils/formatFileSize';
 import LinkButton from '../../../generic/linkButton/LinkButton';
 import { getDocument } from 'pdfjs-dist';
-import PatientSummary from '../../../generic/patientSummary/PatientSummary';
+import PatientSummary, { PatientInfo } from '../../../generic/patientSummary/PatientSummary';
 
 export type Props = {
     setDocuments: SetUploadDocuments;
@@ -177,9 +177,9 @@ const DocumentSelectStage = ({ documents, setDocuments, documentType }: Props) =
                 <div className="nhsuk-inset-text">
                     <p>Make sure that all files uploaded are for this patient only:</p>
                     <PatientSummary>
-                        <PatientSummary.PatientFullName />
-                        <PatientSummary.PatientNhsNumber />
-                        <PatientSummary.PatientDob />
+                        <PatientSummary.Child item={PatientInfo.FULL_NAME} />
+                        <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
+                        <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
                     </PatientSummary>
                 </div>
 

--- a/app/src/components/blocks/_documentUpload/documentSelectStage/DocumentSelectStage.tsx
+++ b/app/src/components/blocks/_documentUpload/documentSelectStage/DocumentSelectStage.tsx
@@ -10,12 +10,12 @@ import { v4 as uuidv4 } from 'uuid';
 import BackButton from '../../../generic/backButton/BackButton';
 import { useNavigate } from 'react-router-dom';
 import { routeChildren } from '../../../../types/generic/routes';
-import PatientSimpleSummary from '../../../generic/patientSimpleSummary/PatientSimpleSummary';
 import useTitle from '../../../../helpers/hooks/useTitle';
 import { Button, Fieldset, Table, TextInput } from 'nhsuk-react-components';
 import formatFileSize from '../../../../helpers/utils/formatFileSize';
 import LinkButton from '../../../generic/linkButton/LinkButton';
 import { getDocument } from 'pdfjs-dist';
+import PatientSummary from '../../../generic/patientSummary/PatientSummary';
 
 export type Props = {
     setDocuments: SetUploadDocuments;
@@ -173,7 +173,17 @@ const DocumentSelectStage = ({ documents, setDocuments, documentType }: Props) =
                     Uploading may take longer if there are many files or if individual files are
                     larger
                 </p>
-                <PatientSimpleSummary />
+
+                <div className="nhsuk-inset-text">
+                    <p>Make sure that all files uploaded are for this patient only:</p>
+                    <PatientSummary>
+                        <PatientSummary.PatientFullName />
+                        <PatientSummary.PatientNhsNumber />
+                        <PatientSummary.PatientDob />
+                    </PatientSummary>
+                </div>
+
+                <p>You can only upload PDF files.</p>
             </div>
             <Fieldset.Legend id="upload-fieldset-legend" size="m">
                 Choose PDF files to upload

--- a/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.test.tsx
+++ b/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.test.tsx
@@ -1,6 +1,11 @@
 import { render, waitFor, screen } from '@testing-library/react';
 import DocumentUploadConfirmStage from './DocumentUploadConfirmStage';
-import { UploadDocument } from '../../../../types/pages/UploadDocumentsPage/types';
+import { DOCUMENT_TYPE, UploadDocument } from '../../../../types/pages/UploadDocumentsPage/types';
+import { formatNhsNumber } from '../../../../helpers/utils/formatNhsNumber';
+import { getFormattedDate } from '../../../../helpers/utils/formatDate';
+import DocumentSelectStage from '../documentSelectStage/DocumentSelectStage';
+import { buildPatientDetails } from '../../../../helpers/test/testBuilders';
+import usePatient from '../../../../helpers/hooks/usePatient';
 
 const mockNavigate = vi.fn();
 vi.mock('../../../../helpers/hooks/usePatient');
@@ -8,11 +13,15 @@ vi.mock('react-router-dom', () => ({
     useNavigate: () => mockNavigate,
 }));
 
+const patientDetails = buildPatientDetails();
+
 URL.createObjectURL = vi.fn();
 
 describe('DocumentUploadCompleteStage', () => {
     let documents: UploadDocument[];
     beforeEach(() => {
+        vi.mocked(usePatient).mockReturnValue(patientDetails);
+
         import.meta.env.VITE_ENVIRONMENT = 'vitest';
         documents = [];
     });
@@ -22,16 +31,38 @@ describe('DocumentUploadCompleteStage', () => {
 
     describe('Rendering', () => {
         it('renders', async () => {
-            render(
-                <DocumentUploadConfirmStage
-                    documents={documents}
-                    startUpload={() => Promise.resolve()}
-                />,
-            );
+            renderSut(documents);
 
             await waitFor(async () => {
                 expect(screen.getByText('Check your files before uploading')).toBeInTheDocument();
             });
         });
+
+        it('renders patient summary fields is inset', async () => {
+            renderSut(documents);
+
+            const insetText = screen
+                .getByText('Make sure that all files uploaded are for this patient only:')
+                .closest('.nhsuk-inset-text');
+            expect(insetText).toBeInTheDocument();
+
+            const expectedFullName = `${patientDetails.familyName}, ${patientDetails.givenName}`;
+            expect(screen.getByText(/Patient name/i)).toBeInTheDocument();
+            expect(screen.getByText(expectedFullName)).toBeInTheDocument();
+
+            expect(screen.getByText(/NHS number/i)).toBeInTheDocument();
+            const expectedNhsNumber = formatNhsNumber(patientDetails.nhsNumber);
+            expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
+
+            expect(screen.getByText(/Date of birth/i)).toBeInTheDocument();
+            const expectedDob = getFormattedDate(new Date(patientDetails.birthDate));
+            expect(screen.getByText(expectedDob)).toBeInTheDocument();
+        });
     });
 });
+
+function renderSut(documents: UploadDocument[]) {
+    render(
+        <DocumentUploadConfirmStage documents={documents} startUpload={() => Promise.resolve()} />,
+    );
+}

--- a/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.test.tsx
+++ b/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.test.tsx
@@ -1,9 +1,8 @@
 import { render, waitFor, screen } from '@testing-library/react';
 import DocumentUploadConfirmStage from './DocumentUploadConfirmStage';
-import { DOCUMENT_TYPE, UploadDocument } from '../../../../types/pages/UploadDocumentsPage/types';
+import { UploadDocument } from '../../../../types/pages/UploadDocumentsPage/types';
 import { formatNhsNumber } from '../../../../helpers/utils/formatNhsNumber';
 import { getFormattedDate } from '../../../../helpers/utils/formatDate';
-import DocumentSelectStage from '../documentSelectStage/DocumentSelectStage';
 import { buildPatientDetails } from '../../../../helpers/test/testBuilders';
 import usePatient from '../../../../helpers/hooks/usePatient';
 

--- a/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.tsx
+++ b/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { routes } from '../../../../types/generic/routes';
 import { useState } from 'react';
 import Pagination from '../../../generic/pagination/Pagination';
-import PatientSummary from '../../../generic/patientSummary/PatientSummary';
+import PatientSummary, { PatientInfo } from '../../../generic/patientSummary/PatientSummary';
 
 type Props = {
     documents: UploadDocument[];
@@ -41,9 +41,9 @@ const DocumentUploadConfirmStage = ({ documents, startUpload }: Props) => {
             <div className="nhsuk-inset-text">
                 <p>Make sure that all files uploaded are for this patient only:</p>
                 <PatientSummary>
-                    <PatientSummary.PatientFullName />
-                    <PatientSummary.PatientNhsNumber />
-                    <PatientSummary.PatientDob />
+                    <PatientSummary.Child item={PatientInfo.FULL_NAME} />
+                    <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
+                    <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
                 </PatientSummary>
             </div>
             <div style={{ borderBottom: '1px solid black' }}>

--- a/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.tsx
+++ b/app/src/components/blocks/_documentUpload/documentUploadConfirmStage/DocumentUploadConfirmStage.tsx
@@ -1,12 +1,12 @@
 import { Button, Table } from 'nhsuk-react-components';
 import useTitle from '../../../../helpers/hooks/useTitle';
 import { DOCUMENT_TYPE, UploadDocument } from '../../../../types/pages/UploadDocumentsPage/types';
-import PatientSimpleSummary from '../../../generic/patientSimpleSummary/PatientSimpleSummary';
 import BackButton from '../../../generic/backButton/BackButton';
 import { useNavigate } from 'react-router-dom';
 import { routes } from '../../../../types/generic/routes';
 import { useState } from 'react';
 import Pagination from '../../../generic/pagination/Pagination';
+import PatientSummary from '../../../generic/patientSummary/PatientSummary';
 
 type Props = {
     documents: UploadDocument[];
@@ -38,8 +38,14 @@ const DocumentUploadConfirmStage = ({ documents, startUpload }: Props) => {
                 Files will be combined into a single PDF document to create a digital Lloyd George
                 record for:
             </p>
-            <PatientSimpleSummary />
-
+            <div className="nhsuk-inset-text">
+                <p>Make sure that all files uploaded are for this patient only:</p>
+                <PatientSummary>
+                    <PatientSummary.PatientFullName />
+                    <PatientSummary.PatientNhsNumber />
+                    <PatientSummary.PatientDob />
+                </PatientSummary>
+            </div>
             <div style={{ borderBottom: '1px solid black' }}>
                 <h4 style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
                     <span>Files to be uploaded</span>

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.test.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.test.tsx
@@ -125,7 +125,7 @@ describe('<LloydGeorgeViewRecordStage />', () => {
         });
 
         it('shows full screen mode with patient info', async () => {
-            const patientName = `${mockPatientDetails.givenName}, ${mockPatientDetails.familyName}`;
+            const patientName = `${mockPatientDetails.familyName}, ${mockPatientDetails.givenName}`;
             const dob = getFormattedDate(new Date(mockPatientDetails.birthDate));
 
             renderComponent();
@@ -136,7 +136,7 @@ describe('<LloydGeorgeViewRecordStage />', () => {
             await screen.findByText('Exit full screen');
 
             expect(screen.getByText(patientName)).toBeInTheDocument();
-            expect(screen.getByText(`Date of birth: ${dob}`)).toBeInTheDocument();
+            expect(screen.getByText(dob)).toBeInTheDocument();
             expect(screen.getByText(/NHS number/)).toBeInTheDocument();
         });
 

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.test.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.test.tsx
@@ -140,6 +140,13 @@ describe('<LloydGeorgeViewRecordStage />', () => {
             expect(screen.getByText(/NHS number/)).toBeInTheDocument();
         });
 
+        it('shows deceased tag for deceased patients', async () => {
+            mockedUsePatient.mockReturnValue(buildPatientDetails({ deceased: true }));
+            renderComponent();
+
+            expect(screen.getByTestId('deceased-patient-tag')).toBeInTheDocument();
+        });
+
         it('returns to regular view when exiting full screen', async () => {
             renderComponent();
 

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.tsx
@@ -10,12 +10,12 @@ import { getUserRecordActionLinks } from '../../../../types/blocks/lloydGeorgeAc
 import RecordCard from '../../../generic/recordCard/RecordCard';
 import useTitle from '../../../../helpers/hooks/useTitle';
 import { routes, routeChildren } from '../../../../types/generic/routes';
-import PatientSimpleSummary from '../../../generic/patientSimpleSummary/PatientSimpleSummary';
 import ProgressBar from '../../../generic/progressBar/ProgressBar';
 import usePatient from '../../../../helpers/hooks/usePatient';
 import { useSessionContext } from '../../../../providers/sessionProvider/SessionProvider';
 import RecordMenuCard from '../../../generic/recordMenuCard/RecordMenuCard';
 import { REPOSITORY_ROLE } from '../../../../types/generic/authRole';
+import PatientSummary from '../../../generic/patientSummary/PatientSummary';
 
 export type Props = {
     downloadStage: DOWNLOAD_STAGE;
@@ -134,7 +134,11 @@ function LloydGeorgeViewRecordStage({
                         </>
                     )}
 
-                    <PatientSimpleSummary showDeceasedTag />
+                    <PatientSummary>
+                        <PatientSummary.PatientFullName />
+                        <PatientSummary.PatientNhsNumber />
+                        <PatientSummary.PatientDob />
+                    </PatientSummary>
 
                     {session.isFullscreen && (
                         <RecordMenuCard

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.tsx
@@ -134,7 +134,7 @@ function LloydGeorgeViewRecordStage({
                         </>
                     )}
 
-                    <PatientSummary>
+                    <PatientSummary showDeceasedTag>
                         <PatientSummary.PatientFullName />
                         <PatientSummary.PatientNhsNumber />
                         <PatientSummary.PatientDob />

--- a/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.tsx
+++ b/app/src/components/blocks/_lloydGeorge/lloydGeorgeViewRecordStage/LloydGeorgeViewRecordStage.tsx
@@ -15,7 +15,7 @@ import usePatient from '../../../../helpers/hooks/usePatient';
 import { useSessionContext } from '../../../../providers/sessionProvider/SessionProvider';
 import RecordMenuCard from '../../../generic/recordMenuCard/RecordMenuCard';
 import { REPOSITORY_ROLE } from '../../../../types/generic/authRole';
-import PatientSummary from '../../../generic/patientSummary/PatientSummary';
+import PatientSummary, { PatientInfo } from '../../../generic/patientSummary/PatientSummary';
 
 export type Props = {
     downloadStage: DOWNLOAD_STAGE;
@@ -135,9 +135,9 @@ function LloydGeorgeViewRecordStage({
                     )}
 
                     <PatientSummary showDeceasedTag>
-                        <PatientSummary.PatientFullName />
-                        <PatientSummary.PatientNhsNumber />
-                        <PatientSummary.PatientDob />
+                        <PatientSummary.Child item={PatientInfo.FULL_NAME} />
+                        <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
+                        <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
                     </PatientSummary>
 
                     {session.isFullscreen && (

--- a/app/src/components/blocks/_patientAccessAudit/deceasedPatientAccessAudit/DeceasedPatientAccessAudit.test.tsx
+++ b/app/src/components/blocks/_patientAccessAudit/deceasedPatientAccessAudit/DeceasedPatientAccessAudit.test.tsx
@@ -18,6 +18,8 @@ import PatientAccessAuditProvider from '../../../../providers/patientAccessAudit
 import ConfigProvider from '../../../../providers/configProvider/ConfigProvider';
 import PatientDetailsProvider from '../../../../providers/patientProvider/PatientProvider';
 import { beforeEach, describe, expect, it, vi, Mock } from 'vitest';
+import { formatNhsNumber } from '../../../../helpers/utils/formatNhsNumber';
+import { getFormattedDate } from '../../../../helpers/utils/formatDate';
 
 const mockedUseNavigate = vi.fn();
 vi.mock('react-router-dom', async () => ({
@@ -53,9 +55,11 @@ describe('DeceasedPatientAccessAudit', () => {
             renderDeceasedPatientAccessAudit();
 
             const title = screen.getByTestId('title');
+            const expectedNhsNumber = formatNhsNumber(mockPatientDetails.nhsNumber);
+
             expect(title).toBeInTheDocument();
             expect(title.innerHTML).toContain('Deceased patient record');
-            expect(screen.getByTestId('patient-nhs-number')).toBeInTheDocument();
+            expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
             expect(screen.queryByTestId('access-reason-error-box')).not.toBeInTheDocument();
 
             Object.values(DeceasedAccessAuditReasons).forEach((reason) => {
@@ -110,6 +114,22 @@ describe('DeceasedPatientAccessAudit', () => {
                     'Enter a reason why you need to access this record',
                 );
             });
+        });
+
+        it('renders patient summary fields', async () => {
+            renderDeceasedPatientAccessAudit();
+
+            const expectedFullName = `${mockPatientDetails.familyName}, ${mockPatientDetails.givenName}`;
+            expect(screen.getByText(/Patient name/i)).toBeInTheDocument();
+            expect(screen.getByText(expectedFullName)).toBeInTheDocument();
+
+            expect(screen.getByText(/NHS number/i)).toBeInTheDocument();
+            const expectedNhsNumber = formatNhsNumber(mockPatientDetails.nhsNumber);
+            expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
+
+            expect(screen.getByText(/Date of birth/i)).toBeInTheDocument();
+            const expectedDob = getFormattedDate(new Date(mockPatientDetails.birthDate));
+            expect(screen.getByText(expectedDob)).toBeInTheDocument();
         });
     });
 

--- a/app/src/components/blocks/_patientAccessAudit/deceasedPatientAccessAudit/DeceasedPatientAccessAudit.tsx
+++ b/app/src/components/blocks/_patientAccessAudit/deceasedPatientAccessAudit/DeceasedPatientAccessAudit.tsx
@@ -23,7 +23,7 @@ import { TextAreaRef } from '../../../../types/generic/textareaRef';
 import { usePatientAccessAuditContext } from '../../../../providers/patientAccessAuditProvider/PatientAccessAuditProvider';
 import SpinnerButton from '../../../generic/spinnerButton/SpinnerButton';
 import postPatientAccessAudit from '../../../../helpers/requests/postPatientAccessAudit';
-import PatientSummary from '../../../generic/patientSummary/PatientSummary';
+import PatientSummary, { PatientInfo } from '../../../generic/patientSummary/PatientSummary';
 
 enum FORM_FIELDS {
     Reasons = 'reasons',
@@ -239,9 +239,9 @@ const DeceasedPatientAccessAudit = () => {
             <h1 data-testid="title">{pageTitle}</h1>
 
             <PatientSummary>
-                <PatientSummary.PatientFullName />
-                <PatientSummary.PatientNhsNumber />
-                <PatientSummary.PatientDob />
+                <PatientSummary.Child item={PatientInfo.FULL_NAME} />
+                <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
+                <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
             </PatientSummary>
 
             <h2>Why do you need to access this record?</h2>

--- a/app/src/components/blocks/_patientAccessAudit/deceasedPatientAccessAudit/DeceasedPatientAccessAudit.tsx
+++ b/app/src/components/blocks/_patientAccessAudit/deceasedPatientAccessAudit/DeceasedPatientAccessAudit.tsx
@@ -23,7 +23,7 @@ import { TextAreaRef } from '../../../../types/generic/textareaRef';
 import { usePatientAccessAuditContext } from '../../../../providers/patientAccessAuditProvider/PatientAccessAuditProvider';
 import SpinnerButton from '../../../generic/spinnerButton/SpinnerButton';
 import postPatientAccessAudit from '../../../../helpers/requests/postPatientAccessAudit';
-import PatientSimpleSummary from '../../../generic/patientSimpleSummary/PatientSimpleSummary';
+import PatientSummary from '../../../generic/patientSummary/PatientSummary';
 
 enum FORM_FIELDS {
     Reasons = 'reasons',
@@ -238,7 +238,11 @@ const DeceasedPatientAccessAudit = () => {
 
             <h1 data-testid="title">{pageTitle}</h1>
 
-            <PatientSimpleSummary />
+            <PatientSummary>
+                <PatientSummary.PatientFullName />
+                <PatientSummary.PatientNhsNumber />
+                <PatientSummary.PatientDob />
+            </PatientSummary>
 
             <h2>Why do you need to access this record?</h2>
             <p>Select all options that are relevant.</p>

--- a/app/src/components/blocks/testPanel/TestPanel.tsx
+++ b/app/src/components/blocks/testPanel/TestPanel.tsx
@@ -7,7 +7,8 @@ import TestToggle, { ToggleProps } from './TestToggle';
 
 function TestPanel() {
     const [config, setConfig] = useConfigContext();
-    const { recordUploaded, userRole, patientIsActive, uploading } = config.mockLocal;
+    const { recordUploaded, userRole, patientIsActive, uploading, patientIsDeceased } =
+        config.mockLocal;
 
     const updateLocalFlag = (key: keyof LocalFlags, value: boolean | REPOSITORY_ROLE) => {
         setConfig({
@@ -49,6 +50,13 @@ function TestPanel() {
             checked: !!recordUploaded,
             onChange: () => {
                 updateLocalFlag('recordUploaded', !recordUploaded);
+            },
+        },
+        'deceased-toggle': {
+            label: 'Patient is deceased',
+            checked: !!patientIsDeceased,
+            onChange: () => {
+                updateLocalFlag('patientIsDeceased', !patientIsDeceased);
             },
         },
         'uploading-toggle': {

--- a/app/src/components/generic/patientSummary/PatientSummary.test.tsx
+++ b/app/src/components/generic/patientSummary/PatientSummary.test.tsx
@@ -1,5 +1,6 @@
 import usePatient from '../../../helpers/hooks/usePatient';
 import { buildPatientDetails } from '../../../helpers/test/testBuilders';
+import { formatNhsNumber } from '../../../helpers/utils/formatNhsNumber';
 import PatientSummary from './PatientSummary';
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, Mock } from 'vitest';
@@ -23,8 +24,9 @@ describe('PatientSummary', () => {
 
         mockedUsePatient.mockReturnValue(mockDetails);
         render(<PatientSummary />);
+        const expectedNhsNumber = formatNhsNumber(mockDetails.nhsNumber);
 
-        expect(screen.getByText(mockDetails.nhsNumber)).toBeInTheDocument();
+        expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
         expect(screen.getByText(mockDetails.familyName)).toBeInTheDocument();
     });
 
@@ -74,5 +76,215 @@ describe('PatientSummary', () => {
         render(<PatientSummary />);
 
         expect(screen.queryByTestId('deceased-patient-tag')).not.toBeInTheDocument();
+    });
+
+    describe('Compound Component Pattern', () => {
+        it('renders children when children prop is provided', () => {
+            const mockDetails = buildPatientDetails({
+                familyName: 'Smith',
+                nhsNumber: '1234567890',
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientNhsNumber />
+                    <PatientSummary.PatientFamilyName />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+            expect(screen.getByText('123 456 7890')).toBeInTheDocument();
+            expect(screen.getByText('Smith')).toBeInTheDocument();
+        });
+
+        it('renders deceased tag with children when showDeceasedTag is true and patient is deceased', () => {
+            const mockDetails = buildPatientDetails({
+                deceased: true,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary showDeceasedTag>
+                    <PatientSummary.PatientNhsNumber />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('deceased-patient-tag')).toBeInTheDocument();
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+        });
+
+        it('does not render deceased tag with children when showDeceasedTag is false', () => {
+            const mockDetails = buildPatientDetails({
+                deceased: true,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientNhsNumber />
+                </PatientSummary>,
+            );
+
+            expect(screen.queryByTestId('deceased-patient-tag')).not.toBeInTheDocument();
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+        });
+    });
+
+    describe('Individual Subcomponents', () => {
+        it('renders PatientFullName correctly', () => {
+            const mockDetails = buildPatientDetails({
+                familyName: 'Smith',
+                givenName: ['John', 'Michael'],
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientFullName />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByText('Smith, John Michael')).toBeInTheDocument();
+        });
+
+        it('handles null patient details gracefully', () => {
+            mockedUsePatient.mockReturnValue(null);
+            render(<PatientSummary />);
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+            // Components should render but with empty/default values
+        });
+
+        it('handles empty NHS number', () => {
+            const mockDetails = buildPatientDetails({
+                nhsNumber: '',
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientNhsNumber />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+        });
+
+        it('handles undefined givenName', () => {
+            const mockDetails = buildPatientDetails({
+                givenName: undefined,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientGivenName />
+                    <PatientSummary.PatientFullName />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+        });
+
+        it('handles empty givenName array', () => {
+            const mockDetails = buildPatientDetails({
+                givenName: [],
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientGivenName />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+        });
+
+        it('handles undefined birthDate', () => {
+            const mockDetails = buildPatientDetails({
+                birthDate: undefined,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientDob />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+            // Should render empty string for date - check by ID
+            const dobElement = document.getElementById('patient-summary-date-of-birth');
+            expect(dobElement).toHaveTextContent('');
+        });
+
+        it('handles undefined postalCode', () => {
+            const mockDetails = buildPatientDetails({
+                postalCode: undefined,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientPostcode />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+        });
+
+        it('handles undefined familyName', () => {
+            const mockDetails = buildPatientDetails({
+                familyName: undefined,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.PatientFamilyName />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+        });
+    });
+
+    describe('Context Error Handling', () => {
+        it('throws error when PatientSummary subcomponents are used outside of PatientSummary', () => {
+            // Suppress error output for this test as we expect it to throw
+            const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            expect(() => {
+                render(<PatientSummary.PatientNhsNumber />);
+            }).toThrow('PatientSummary subcomponents must be used within PatientSummary');
+
+            spy.mockRestore();
+        });
+    });
+
+    describe('Edge Cases for Optional Fields', () => {
+        it('renders correctly when patient is deceased but showDeceasedTag is undefined', () => {
+            const mockDetails = buildPatientDetails({
+                deceased: true,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(<PatientSummary showDeceasedTag={undefined} />);
+
+            expect(screen.queryByTestId('deceased-patient-tag')).not.toBeInTheDocument();
+        });
+
+        it('renders correctly when patient deceased status is undefined', () => {
+            const mockDetails = buildPatientDetails({
+                deceased: undefined,
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(<PatientSummary showDeceasedTag />);
+
+            expect(screen.queryByTestId('deceased-patient-tag')).not.toBeInTheDocument();
+        });
     });
 });

--- a/app/src/components/generic/patientSummary/PatientSummary.test.tsx
+++ b/app/src/components/generic/patientSummary/PatientSummary.test.tsx
@@ -1,7 +1,7 @@
 import usePatient from '../../../helpers/hooks/usePatient';
 import { buildPatientDetails } from '../../../helpers/test/testBuilders';
 import { formatNhsNumber } from '../../../helpers/utils/formatNhsNumber';
-import PatientSummary from './PatientSummary';
+import PatientSummary, { PatientInfo } from './PatientSummary';
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, Mock } from 'vitest';
 
@@ -28,6 +28,39 @@ describe('PatientSummary', () => {
 
         expect(screen.getByText(expectedNhsNumber)).toBeInTheDocument();
         expect(screen.getByText(mockDetails.familyName)).toBeInTheDocument();
+    });
+
+    it('renders postal code correct', () => {
+        const mockDetails = buildPatientDetails({
+            postalCode: 'SW1A 1AA',
+        });
+        mockedUsePatient.mockReturnValue(mockDetails);
+        render(<PatientSummary />);
+        expect(screen.getByTestId('patient-summary-postal-code')).toBeInTheDocument();
+        expect(screen.getByText('SW1A 1AA')).toBeInTheDocument();
+        expect(screen.getByText('Postcode')).toBeInTheDocument();
+    });
+
+    it('renders family name correct', () => {
+        const mockDetails = buildPatientDetails({
+            familyName: 'Smith',
+        });
+        mockedUsePatient.mockReturnValue(mockDetails);
+        render(<PatientSummary />);
+        expect(screen.getByTestId('patient-summary-family-name')).toBeInTheDocument();
+        expect(screen.getByText('Smith')).toBeInTheDocument();
+        expect(screen.getByText('Surname')).toBeInTheDocument();
+    });
+
+    it('renders given name correct', () => {
+        const mockDetails = buildPatientDetails({
+            givenName: ['John', 'Michael'],
+        });
+        mockedUsePatient.mockReturnValue(mockDetails);
+        render(<PatientSummary />);
+        expect(screen.getByText('John Michael')).toBeInTheDocument();
+        expect(screen.getByTestId('patient-summary-given-name')).toBeInTheDocument();
+        expect(screen.getByText('First name')).toBeInTheDocument();
     });
 
     it('renders multiple given names with correct spacing', () => {
@@ -88,14 +121,32 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientNhsNumber />
-                    <PatientSummary.PatientFamilyName />
+                    <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
+                    <PatientSummary.Child item={PatientInfo.FAMILY_NAME} />
                 </PatientSummary>,
             );
 
             expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
             expect(screen.getByText('123 456 7890')).toBeInTheDocument();
             expect(screen.getByText('Smith')).toBeInTheDocument();
+        });
+
+        it('renders PatientSummary with info given name correctly', () => {
+            const mockDetails = buildPatientDetails({
+                familyName: 'Smith',
+                givenName: ['John', 'Michael'],
+            });
+
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.Child item={PatientInfo.GIVEN_NAME} />
+                </PatientSummary>,
+            );
+
+            expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+            expect(screen.getByTestId('patient-summary-given-name')).toBeInTheDocument();
+            expect(screen.getByText('John Michael')).toBeInTheDocument();
         });
 
         it('renders deceased tag with children when showDeceasedTag is true and patient is deceased', () => {
@@ -106,7 +157,7 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary showDeceasedTag>
-                    <PatientSummary.PatientNhsNumber />
+                    <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
                 </PatientSummary>,
             );
 
@@ -122,7 +173,7 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientNhsNumber />
+                    <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
                 </PatientSummary>,
             );
 
@@ -141,16 +192,68 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientFullName />
+                    <PatientSummary.Child item={PatientInfo.FULL_NAME} />
                 </PatientSummary>,
             );
 
             expect(screen.getByText('Smith, John Michael')).toBeInTheDocument();
         });
 
+        it('renders postal code correct', () => {
+            const mockDetails = buildPatientDetails({
+                postalCode: 'SW1A 1AA',
+            });
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.Child item={PatientInfo.POSTAL_CODE} />
+                </PatientSummary>,
+            );
+            expect(screen.getByTestId('patient-summary-postal-code')).toBeInTheDocument();
+            expect(screen.getByText('SW1A 1AA')).toBeInTheDocument();
+            expect(screen.getByText('Postcode')).toBeInTheDocument();
+        });
+
+        it('renders family name correct', () => {
+            const mockDetails = buildPatientDetails({
+                familyName: 'Smith',
+            });
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.Child item={PatientInfo.FAMILY_NAME} />
+                </PatientSummary>,
+            );
+            expect(screen.getByTestId('patient-summary-family-name')).toBeInTheDocument();
+            expect(screen.getByText('Smith')).toBeInTheDocument();
+            expect(screen.getByText('Surname')).toBeInTheDocument();
+        });
+
+        it('renders given name correct', () => {
+            const mockDetails = buildPatientDetails({
+                givenName: ['John', 'Michael'],
+            });
+            mockedUsePatient.mockReturnValue(mockDetails);
+            render(
+                <PatientSummary>
+                    <PatientSummary.Child item={PatientInfo.GIVEN_NAME} />
+                </PatientSummary>,
+            );
+            expect(screen.getByText('John Michael')).toBeInTheDocument();
+            expect(screen.getByTestId('patient-summary-given-name')).toBeInTheDocument();
+            expect(screen.getByText('First name')).toBeInTheDocument();
+        });
+
         it('handles null patient details gracefully', () => {
             mockedUsePatient.mockReturnValue(null);
-            render(<PatientSummary />);
+            render(
+                <PatientSummary>
+                    <PatientSummary.Child item={PatientInfo.FAMILY_NAME} />
+                    <PatientSummary.Child item={PatientInfo.GIVEN_NAME} />
+                    <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
+                    <PatientSummary.Child item={PatientInfo.POSTAL_CODE} />
+                </PatientSummary>,
+            );
 
             expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
             // Components should render but with empty/default values
@@ -164,7 +267,7 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientNhsNumber />
+                    <PatientSummary.Child item={PatientInfo.NHS_NUMBER} />
                 </PatientSummary>,
             );
 
@@ -179,8 +282,8 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientGivenName />
-                    <PatientSummary.PatientFullName />
+                    <PatientSummary.Child item={PatientInfo.GIVEN_NAME} />
+                    <PatientSummary.Child item={PatientInfo.FULL_NAME} />
                 </PatientSummary>,
             );
 
@@ -195,7 +298,7 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientGivenName />
+                    <PatientSummary.Child item={PatientInfo.GIVEN_NAME} />
                 </PatientSummary>,
             );
 
@@ -210,7 +313,7 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientDob />
+                    <PatientSummary.Child item={PatientInfo.BIRTH_DATE} />
                 </PatientSummary>,
             );
 
@@ -228,7 +331,7 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientPostcode />
+                    <PatientSummary.Child item={PatientInfo.POSTAL_CODE} />
                 </PatientSummary>,
             );
 
@@ -243,11 +346,12 @@ describe('PatientSummary', () => {
             mockedUsePatient.mockReturnValue(mockDetails);
             render(
                 <PatientSummary>
-                    <PatientSummary.PatientFamilyName />
+                    <PatientSummary.Child item={PatientInfo.FAMILY_NAME} />
                 </PatientSummary>,
             );
 
             expect(screen.getByTestId('patient-summary')).toBeInTheDocument();
+            expect(screen.getByTestId('patient-summary-family-name')).toBeInTheDocument();
         });
     });
 
@@ -257,7 +361,7 @@ describe('PatientSummary', () => {
             const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
             expect(() => {
-                render(<PatientSummary.PatientNhsNumber />);
+                render(<PatientSummary.Child item={PatientInfo.NHS_NUMBER} />);
             }).toThrow('PatientSummary subcomponents must be used within PatientSummary');
 
             spy.mockRestore();

--- a/app/src/components/generic/patientSummary/PatientSummary.tsx
+++ b/app/src/components/generic/patientSummary/PatientSummary.tsx
@@ -1,11 +1,61 @@
+import { ReactNode, createContext, useContext } from 'react';
 import usePatient from '../../../helpers/hooks/usePatient';
 import { getFormattedDate } from '../../../helpers/utils/formatDate';
 import { SummaryList, Tag } from 'nhsuk-react-components';
-type Props = {
-    showDeceasedTag?: boolean;
+import type { PatientDetails } from '../../../types/generic/patientDetails';
+import { formatNhsNumber } from '../../../helpers/utils/formatNhsNumber';
+
+// Context for sharing patient data and configuration
+type PatientSummaryContextType = {
+    patientDetails: PatientDetails | null;
+    joinNames?: boolean;
 };
-const PatientSummary = ({ showDeceasedTag = false }: Props) => {
+
+const PatientSummaryContext = createContext<PatientSummaryContextType | null>(null);
+
+const usePatientSummaryContext = () => {
+    const context = useContext(PatientSummaryContext);
+    if (!context) {
+        throw new Error('PatientSummary subcomponents must be used within PatientSummary');
+    }
+    return context;
+};
+
+// Main PatientSummary component
+type PatientSummaryProps = {
+    showDeceasedTag?: boolean;
+    joinNames?: boolean;
+    children?: ReactNode;
+    // Legacy props for backward compatibility
+    detailsToDisplay?: Array<
+        keyof Pick<
+            PatientDetails,
+            'nhsNumber' | 'familyName' | 'givenName' | 'birthDate' | 'postalCode'
+        >
+    >;
+};
+
+const PatientSummary = ({ showDeceasedTag = false, children }: PatientSummaryProps) => {
     const patientDetails = usePatient();
+
+    // If children are provided, use compound component pattern
+    if (children) {
+        return (
+            <PatientSummaryContext.Provider value={{ patientDetails }}>
+                <>
+                    {showDeceasedTag && patientDetails?.deceased && (
+                        <Tag color="blue" className="mb-6" data-testid="deceased-patient-tag">
+                            Deceased patient
+                        </Tag>
+                    )}
+                    <SummaryList id="patient-summary" data-testid="patient-summary">
+                        {children}
+                    </SummaryList>
+                </>
+            </PatientSummaryContext.Provider>
+        );
+    }
+
     return (
         <>
             {showDeceasedTag && patientDetails?.deceased && (
@@ -13,40 +63,101 @@ const PatientSummary = ({ showDeceasedTag = false }: Props) => {
                     Deceased patient
                 </Tag>
             )}
-            <SummaryList id="patient-summary" data-testid="patient-summary">
-                <SummaryList.Row>
-                    <SummaryList.Key>NHS number</SummaryList.Key>
-                    <SummaryList.Value id="patient-summary-nhs-number">
-                        {patientDetails?.nhsNumber}
-                    </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                    <SummaryList.Key>Surname</SummaryList.Key>
-                    <SummaryList.Value id="patient-summary-family-name">
-                        {patientDetails?.familyName}
-                    </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                    <SummaryList.Key>First name</SummaryList.Key>
-                    <SummaryList.Value id="patient-summary-given-name">
-                        {patientDetails?.givenName?.map((name) => `${name} `)}
-                    </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                    <SummaryList.Key>Date of birth</SummaryList.Key>
-                    <SummaryList.Value id="patient-summary-date-of-birth">
-                        {getFormattedDate(new Date(patientDetails?.birthDate ?? ''))}
-                    </SummaryList.Value>
-                </SummaryList.Row>
-                <SummaryList.Row>
-                    <SummaryList.Key>Postcode</SummaryList.Key>
-                    <SummaryList.Value id="patient-summary-postcode">
-                        {patientDetails?.postalCode}
-                    </SummaryList.Value>
-                </SummaryList.Row>
-            </SummaryList>
+            <PatientSummaryContext.Provider value={{ patientDetails }}>
+                <SummaryList id="patient-summary" data-testid="patient-summary">
+                    <PatientNhsNumber />
+                    <PatientFamilyName />
+                    <PatientGivenName />
+                    <PatientDob />
+                    <PatientPostcode />
+                </SummaryList>
+            </PatientSummaryContext.Provider>
         </>
     );
 };
+
+// Subcomponents
+const PatientNhsNumber = () => {
+    const { patientDetails } = usePatientSummaryContext();
+    return (
+        <SummaryList.Row>
+            <SummaryList.Key>NHS number</SummaryList.Key>
+            <SummaryList.Value id="patient-summary-nhs-number">
+                {formatNhsNumber(patientDetails?.nhsNumber ?? '')}
+            </SummaryList.Value>
+        </SummaryList.Row>
+    );
+};
+
+const PatientFullName = () => {
+    const { patientDetails } = usePatientSummaryContext();
+
+    return (
+        <SummaryList.Row>
+            <SummaryList.Key>Patient name</SummaryList.Key>
+            <SummaryList.Value id="patient-summary-full-name">
+                {`${patientDetails?.familyName}, ${patientDetails?.givenName?.join(' ')}`}
+            </SummaryList.Value>
+        </SummaryList.Row>
+    );
+};
+
+const PatientGivenName = () => {
+    const { patientDetails } = usePatientSummaryContext();
+    return (
+        <SummaryList.Row>
+            <SummaryList.Key>First name</SummaryList.Key>
+            <SummaryList.Value id="patient-summary-given-name">
+                {patientDetails?.givenName?.join(' ')}
+            </SummaryList.Value>
+        </SummaryList.Row>
+    );
+};
+
+const PatientFamilyName = () => {
+    const { patientDetails } = usePatientSummaryContext();
+    return (
+        <SummaryList.Row>
+            <SummaryList.Key>Surname</SummaryList.Key>
+            <SummaryList.Value id="patient-summary-family-name">
+                {patientDetails?.familyName}
+            </SummaryList.Value>
+        </SummaryList.Row>
+    );
+};
+
+const PatientDob = () => {
+    const { patientDetails } = usePatientSummaryContext();
+    return (
+        <SummaryList.Row>
+            <SummaryList.Key>Date of birth</SummaryList.Key>
+            <SummaryList.Value id="patient-summary-date-of-birth">
+                {patientDetails?.birthDate
+                    ? getFormattedDate(new Date(patientDetails.birthDate))
+                    : ''}
+            </SummaryList.Value>
+        </SummaryList.Row>
+    );
+};
+
+const PatientPostcode = () => {
+    const { patientDetails } = usePatientSummaryContext();
+    return (
+        <SummaryList.Row>
+            <SummaryList.Key>Postcode</SummaryList.Key>
+            <SummaryList.Value id="patient-summary-postcode">
+                {patientDetails?.postalCode}
+            </SummaryList.Value>
+        </SummaryList.Row>
+    );
+};
+
+// Attach subcomponents to PatientSummary
+PatientSummary.PatientNhsNumber = PatientNhsNumber;
+PatientSummary.PatientFullName = PatientFullName;
+PatientSummary.PatientGivenName = PatientGivenName;
+PatientSummary.PatientFamilyName = PatientFamilyName;
+PatientSummary.PatientDob = PatientDob;
+PatientSummary.PatientPostcode = PatientPostcode;
 
 export default PatientSummary;

--- a/app/src/components/generic/patientSummary/PatientSummary.tsx
+++ b/app/src/components/generic/patientSummary/PatientSummary.tsx
@@ -8,7 +8,6 @@ import { formatNhsNumber } from '../../../helpers/utils/formatNhsNumber';
 // Context for sharing patient data and configuration
 type PatientSummaryContextType = {
     patientDetails: PatientDetails | null;
-    joinNames?: boolean;
 };
 
 const PatientSummaryContext = createContext<PatientSummaryContextType | null>(null);
@@ -24,7 +23,6 @@ const usePatientSummaryContext = () => {
 // Main PatientSummary component
 type PatientSummaryProps = {
     showDeceasedTag?: boolean;
-    joinNames?: boolean;
     children?: ReactNode;
     // Legacy props for backward compatibility
     detailsToDisplay?: Array<

--- a/app/src/components/generic/patientSummary/PatientSummary.tsx
+++ b/app/src/components/generic/patientSummary/PatientSummary.tsx
@@ -82,7 +82,7 @@ const PatientNhsNumber = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>NHS number</SummaryList.Key>
-            <SummaryList.Value id="patient-summary-nhs-number">
+            <SummaryList.Value data-testid="patient-summary-nhs-number" id="patient-summary-nhs-number">
                 {formatNhsNumber(patientDetails?.nhsNumber ?? '')}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -95,7 +95,7 @@ const PatientFullName = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>Patient name</SummaryList.Key>
-            <SummaryList.Value id="patient-summary-full-name">
+            <SummaryList.Value data-testid="patient-summary-full-name" id="patient-summary-full-name">
                 {`${patientDetails?.familyName}, ${patientDetails?.givenName?.join(' ')}`}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -107,7 +107,7 @@ const PatientGivenName = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>First name</SummaryList.Key>
-            <SummaryList.Value id="patient-summary-given-name">
+            <SummaryList.Value data-testid="patient-summary-given-name" id="patient-summary-given-name">
                 {patientDetails?.givenName?.join(' ')}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -119,7 +119,7 @@ const PatientFamilyName = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>Surname</SummaryList.Key>
-            <SummaryList.Value id="patient-summary-family-name">
+            <SummaryList.Value data-testid="patient-summary-family-name" id="patient-summary-family-name">
                 {patientDetails?.familyName}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -131,7 +131,7 @@ const PatientDob = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>Date of birth</SummaryList.Key>
-            <SummaryList.Value id="patient-summary-date-of-birth">
+            <SummaryList.Value data-testid="patient-summary-date-of-birth" id="patient-summary-date-of-birth">
                 {patientDetails?.birthDate
                     ? getFormattedDate(new Date(patientDetails.birthDate))
                     : ''}
@@ -145,7 +145,7 @@ const PatientPostcode = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>Postcode</SummaryList.Key>
-            <SummaryList.Value id="patient-summary-postcode">
+            <SummaryList.Value data-testid="patient-summary-postcode" id="patient-summary-postcode">
                 {patientDetails?.postalCode}
             </SummaryList.Value>
         </SummaryList.Row>

--- a/app/src/components/generic/patientSummary/PatientSummary.tsx
+++ b/app/src/components/generic/patientSummary/PatientSummary.tsx
@@ -82,7 +82,10 @@ const PatientNhsNumber = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>NHS number</SummaryList.Key>
-            <SummaryList.Value data-testid="patient-summary-nhs-number" id="patient-summary-nhs-number">
+            <SummaryList.Value
+                data-testid="patient-summary-nhs-number"
+                id="patient-summary-nhs-number"
+            >
                 {formatNhsNumber(patientDetails?.nhsNumber ?? '')}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -95,7 +98,10 @@ const PatientFullName = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>Patient name</SummaryList.Key>
-            <SummaryList.Value data-testid="patient-summary-full-name" id="patient-summary-full-name">
+            <SummaryList.Value
+                data-testid="patient-summary-full-name"
+                id="patient-summary-full-name"
+            >
                 {`${patientDetails?.familyName}, ${patientDetails?.givenName?.join(' ')}`}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -107,7 +113,10 @@ const PatientGivenName = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>First name</SummaryList.Key>
-            <SummaryList.Value data-testid="patient-summary-given-name" id="patient-summary-given-name">
+            <SummaryList.Value
+                data-testid="patient-summary-given-name"
+                id="patient-summary-given-name"
+            >
                 {patientDetails?.givenName?.join(' ')}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -119,7 +128,10 @@ const PatientFamilyName = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>Surname</SummaryList.Key>
-            <SummaryList.Value data-testid="patient-summary-family-name" id="patient-summary-family-name">
+            <SummaryList.Value
+                data-testid="patient-summary-family-name"
+                id="patient-summary-family-name"
+            >
                 {patientDetails?.familyName}
             </SummaryList.Value>
         </SummaryList.Row>
@@ -131,7 +143,10 @@ const PatientDob = () => {
     return (
         <SummaryList.Row>
             <SummaryList.Key>Date of birth</SummaryList.Key>
-            <SummaryList.Value data-testid="patient-summary-date-of-birth" id="patient-summary-date-of-birth">
+            <SummaryList.Value
+                data-testid="patient-summary-date-of-birth"
+                id="patient-summary-date-of-birth"
+            >
                 {patientDetails?.birthDate
                     ? getFormattedDate(new Date(patientDetails.birthDate))
                     : ''}

--- a/app/src/pages/lloydGeorgeRecordPage/LloydGeorgeRecordPage.test.tsx
+++ b/app/src/pages/lloydGeorgeRecordPage/LloydGeorgeRecordPage.test.tsx
@@ -62,7 +62,7 @@ describe('LloydGeorgeRecordPage', () => {
     });
 
     it('renders patient details', async () => {
-        const patientName = `${mockPatientDetails.givenName}, ${mockPatientDetails.familyName}`;
+        const patientName = `${mockPatientDetails.familyName}, ${mockPatientDetails.givenName}`;
         const dob = getFormattedDate(new Date(mockPatientDetails.birthDate));
         mockAxios.get.mockReturnValue(Promise.resolve({ data: buildLgSearchResult() }));
 
@@ -71,7 +71,7 @@ describe('LloydGeorgeRecordPage', () => {
         await waitFor(() => {
             expect(screen.getByText(patientName)).toBeInTheDocument();
         });
-        expect(screen.getByText(`Date of birth: ${dob}`)).toBeInTheDocument();
+        expect(screen.getByText(`${dob}`)).toBeInTheDocument();
         expect(screen.getByText(/NHS number/)).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Refactored patient summary components and tests

- Replaced PatientSimpleSummary with PatientSummary component across various stages to improve consistency and maintainability.
- Updated tests to reflect changes in patient name formatting and NHS number display.
- Introduced compound component pattern for PatientSummary to allow for more flexible rendering of patient details.
- Improved test coverage for patient summary fields, ensuring proper rendering of NHS number, full name, date of birth.
- Adjusted rendering logic in DocumentSelectStage, DocumentUploadConfirmStage, and DeceasedPatientAccessAudit to utilize the new PatientSummary structure.

Images can be found on the Jira Ticket
https://nhsd-jira.digital.nhs.uk/browse/PRME-115