### PR TITLE
[NDR-180] Missing Condition in GitHub Action for GET FHIR Lambda Deployment

### DIFF
--- a/.github/workflows/base-lambdas-reusable-deploy-all.yml
+++ b/.github/workflows/base-lambdas-reusable-deploy-all.yml
@@ -409,7 +409,7 @@ jobs:
 
   deploy_get_document_reference_lambda:
     name: Deploy get fhir document reference lambda
-    if: inputs.environment == 'development' ||  inputs.environment == 'test'
+    if: inputs.environment == 'development' || inputs.environment == 'test'
     uses: ./.github/workflows/base-lambdas-reusable-deploy.yml
     with:
       environment: ${{ inputs.environment}}

--- a/.github/workflows/base-lambdas-reusable-deploy-all.yml
+++ b/.github/workflows/base-lambdas-reusable-deploy-all.yml
@@ -211,7 +211,6 @@ jobs:
     secrets:
       AWS_ASSUME_ROLE: ${{ secrets.AWS_ASSUME_ROLE }}
 
-
   deploy_logout_handler_lambda:
     name: Deploy LogoutHandler
     uses: ./.github/workflows/base-lambdas-reusable-deploy.yml
@@ -410,6 +409,7 @@ jobs:
 
   deploy_get_document_reference_lambda:
     name: Deploy get fhir document reference lambda
+    if: inputs.environment == 'development' ||  inputs.environment == 'test'
     uses: ./.github/workflows/base-lambdas-reusable-deploy.yml
     with:
       environment: ${{ inputs.environment}}


### PR DESCRIPTION
As a result of the changes made in ticket NDR-97, there is a missing condition in the GitHub Action workflow that deploys the "Get Document FHIR" Lambda function. This PR makes sure the "Get Document FHIR" Lambda function is only deployed in the test and development environments.