### PR TITLE
[PRMP-124] Resolved issue DocumentUploadLloydGeorgePreview tests

### DIFF
--- a/app/src/components/blocks/_documentUpload/documentUploadLloydGeorgePreview/DocumentUploadLloydGeorgePreview.test.tsx
+++ b/app/src/components/blocks/_documentUpload/documentUploadLloydGeorgePreview/DocumentUploadLloydGeorgePreview.test.tsx
@@ -39,8 +39,9 @@ describe('DocumentUploadCompleteStage', () => {
 
     describe('Rendering', () => {
         it('renders without documents', async () => {
-            // Ensure the async merger resolves immediately (effect will run)
-            vi.mocked(getMergedPdfBlob).mockResolvedValue(new Blob([''], { type: 'application/pdf' }));
+            vi.mocked(getMergedPdfBlob).mockResolvedValue(
+                new Blob([''], { type: 'application/pdf' }),
+            );
 
             await act(async () => {
                 render(
@@ -51,7 +52,6 @@ describe('DocumentUploadCompleteStage', () => {
                 );
             });
 
-            // When no documents are provided, viewer should not render
             expect(screen.queryByTestId('pdf-viewer')).not.toBeInTheDocument();
         });
 
@@ -69,10 +69,8 @@ describe('DocumentUploadCompleteStage', () => {
                 );
             });
 
-            // Await viewer render (implicit act)
             expect(await screen.findByTestId('pdf-viewer')).toBeInTheDocument();
 
-            // Ensure callback invoked with merged blob
             await waitFor(() => {
                 expect(mockSetMergedPdfBlob).toHaveBeenCalledWith(mockBlob);
             });

--- a/app/src/components/blocks/_documentUpload/documentUploadLloydGeorgePreview/DocumentUploadLloydGeorgePreview.tsx
+++ b/app/src/components/blocks/_documentUpload/documentUploadLloydGeorgePreview/DocumentUploadLloydGeorgePreview.tsx
@@ -13,21 +13,23 @@ const DocumentUploadLloydGeorgePreview = ({ documents, setMergedPdfBlob }: Props
 
     const runningRef = useRef(false);
     useEffect(() => {
-        if (!documents || runningRef.current) {
+        // If no docs or effect already running, ensure state cleared and exit
+        if (!documents || documents.length === 0) {
+            if (mergedPdfUrl) {
+                setMergedPdfUrl('');
+            }
             return;
         }
+        if (runningRef.current) return;
 
         runningRef.current = true;
 
         const render = async (): Promise<void> => {
             const blob = await getMergedPdfBlob(documents.map((doc) => doc.file));
-
             setMergedPdfBlob(blob);
-
             const url = URL.createObjectURL(blob);
-
             runningRef.current = false;
-            return setMergedPdfUrl(url);
+            setMergedPdfUrl(url);
         };
 
         render().catch((err) => {


### PR DESCRIPTION
src/components/blocks/_documentUpload/documentUploadLloydGeorgePreview/DocumentUploadLloydGeorgePreview.test.tsx > DocumentUploadCompleteStage > Rendering > renders without documents
An update to DocumentUploadLloydGeorgePreview inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() =>

{   /* fire events that update state */ }
);
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser.

Refactor DocumentUploadLloydGeorgePreview to improve rendering logic and ensure state is cleared when no documents are provided.