### PR TITLE
[NDR-251] Allow PDM routing in a POST DocumentReference

### DIFF
--- a/lambdas/enums/mtls.py
+++ b/lambdas/enums/mtls.py
@@ -1,0 +1,5 @@
+from enum import StrEnum, auto
+
+
+class MtlsCommonNames(StrEnum):
+    PDM = auto()

--- a/lambdas/enums/snomed_codes.py
+++ b/lambdas/enums/snomed_codes.py
@@ -17,6 +17,9 @@ class SnomedCodes(Enum):
     GENERAL_MEDICAL_PRACTICE = SnomedCode(
         code="1060971000000108", display_name="General practice service"
     )
+    UNSTRUCTURED = SnomedCode(
+        code="1234567890987654", display_name="Unstructured records"
+    )
 
     @classmethod
     def find_by_code(cls, code: str) -> Optional["SnomedCode"]:

--- a/lambdas/enums/snomed_codes.py
+++ b/lambdas/enums/snomed_codes.py
@@ -17,8 +17,9 @@ class SnomedCodes(Enum):
     GENERAL_MEDICAL_PRACTICE = SnomedCode(
         code="1060971000000108", display_name="General practice service"
     )
-    UNSTRUCTURED = SnomedCode(
-        code="1234567890987654", display_name="Unstructured records"
+    # Temporary snomed code used.
+    PATIENT_DATA = SnomedCode(
+        code="717391000000106", display_name="Confidential patient data"
     )
 
     @classmethod

--- a/lambdas/handlers/post_fhir_document_reference_handler.py
+++ b/lambdas/handlers/post_fhir_document_reference_handler.py
@@ -31,7 +31,7 @@ def lambda_handler(event, context):
         fhir_doc_ref_service = PostFhirDocumentReferenceService()
 
         fhir_response = fhir_doc_ref_service.process_fhir_document_reference(
-            event.get("body")
+            event.get("body"), event.get("headers")
         )
 
         return ApiGatewayResponse(

--- a/lambdas/services/post_fhir_document_reference_service.py
+++ b/lambdas/services/post_fhir_document_reference_service.py
@@ -163,7 +163,7 @@ class PostFhirDocumentReferenceService:
             logger.error(f"mTLS common name {common_name} - is not supported")
             raise CreateDocumentRefException(400, LambdaError.CreateDocInvalidType)
 
-        return SnomedCodes.UNSTRUCTURED.value
+        return SnomedCodes.PATIENT_DATA.value
 
     def _get_dynamo_table_for_doc_type(self, doc_type: SnomedCode) -> str:
         try:

--- a/lambdas/tests/unit/services/test_post_fhir_document_reference_service.py
+++ b/lambdas/tests/unit/services/test_post_fhir_document_reference_service.py
@@ -775,20 +775,8 @@ def test_determine_document_type_with_correct_common_name(mock_service, mocker):
     fhir_doc = mocker.MagicMock(spec=FhirDocumentReference)
     fhir_doc.type = None
 
-    result = mock_service._determine_document_type(fhir_doc, "pdm")
+    result = mock_service._determine_document_type(fhir_doc, MtlsCommonNames.PDM.value)
     assert result == SnomedCodes.PATIENT_DATA.value
-
-
-def test_determine_document_type_with_incorrect_common_name(mock_service, mocker):
-    """Test _determine_document_type method when type is missing entirely."""
-    fhir_doc = mocker.MagicMock(spec=FhirDocumentReference)
-    fhir_doc.type = None
-
-    with pytest.raises(CreateDocumentRefException) as excinfo:
-        mock_service._determine_document_type(fhir_doc, "foobar")
-
-    assert excinfo.value.status_code == 400
-    assert excinfo.value.error == LambdaError.CreateDocInvalidType
 
 
 def test_validate_valid_common_name(mock_service, mocker, valid_mtls_header):

--- a/lambdas/tests/unit/services/test_post_fhir_document_reference_service.py
+++ b/lambdas/tests/unit/services/test_post_fhir_document_reference_service.py
@@ -775,7 +775,7 @@ def test_determine_document_type_with_correct_common_name(mock_service, mocker):
     fhir_doc = mocker.MagicMock(spec=FhirDocumentReference)
     fhir_doc.type = None
 
-    result = mock_service._determine_document_type(fhir_doc, MtlsCommonNames.PDM.value)
+    result = mock_service._determine_document_type(fhir_doc, MtlsCommonNames.PDM)
     assert result == SnomedCodes.PATIENT_DATA.value
 
 

--- a/lambdas/tests/unit/services/test_post_fhir_document_reference_service.py
+++ b/lambdas/tests/unit/services/test_post_fhir_document_reference_service.py
@@ -140,8 +140,8 @@ def valid_mtls_fhir_doc_json():
                 "coding": [
                     {
                         "system": "http://snomed.info/sct",
-                        "code": SnomedCodes.UNSTRUCTURED.value.code,
-                        "display": SnomedCodes.UNSTRUCTURED.value.display_name,
+                        "code": SnomedCodes.PATIENT_DATA.value.code,
+                        "display": SnomedCodes.PATIENT_DATA.value.display_name,
                     }
                 ]
             },
@@ -427,12 +427,12 @@ def test_extract_nhs_number_from_fhir_with_invalid_system(mock_service, mocker):
     assert excinfo.value.error == LambdaError.CreateDocNoParse
 
 
-def test_get_dynamo_table_for_unstructured_doc_type(mock_service):
+def test_get_dynamo_table_for_patient_data_doc_type(mock_service):
     """Test _get_dynamo_table_for_doc_type method with a non-Lloyd George document type."""
 
-    unstructured_code = SnomedCodes.UNSTRUCTURED.value
+    patient_data_code = SnomedCodes.PATIENT_DATA.value
 
-    result = mock_service._get_dynamo_table_for_doc_type(unstructured_code)
+    result = mock_service._get_dynamo_table_for_doc_type(patient_data_code)
 
     assert result == mock_service.pdm_dynamo_table
 
@@ -776,7 +776,7 @@ def test_determine_document_type_with_correct_common_name(mock_service, mocker):
     fhir_doc.type = None
 
     result = mock_service._determine_document_type(fhir_doc, "pdm")
-    assert result == SnomedCodes.UNSTRUCTURED.value
+    assert result == SnomedCodes.PATIENT_DATA.value
 
 
 def test_determine_document_type_with_incorrect_common_name(mock_service, mocker):

--- a/lambdas/tests/unit/utils/test_dynamo_utils.py
+++ b/lambdas/tests/unit/utils/test_dynamo_utils.py
@@ -168,7 +168,7 @@ def test_parse_dynamo_record_raises_value_error(test_json_string):
     "doc_type, expected_table",
     [
         (SnomedCodes.LLOYD_GEORGE.value, "foo"),
-        (SnomedCodes.UNSTRUCTURED.value, "bar"),
+        (SnomedCodes.PATIENT_DATA.value, "bar"),
     ],
 )
 def test_dynamo_table_mapping(doc_type, expected_table):
@@ -186,7 +186,7 @@ def test_dynamo_table_mapping(doc_type, expected_table):
 def test_dynamo_table_mapping_fails(doc_type):
     table_router = DocTypeTableRouter("foo", "bar")
     with pytest.raises(CreateDocumentRefException) as excinfo:
-        table = table_router.resolve(doc_type)
+        table_router.resolve(doc_type)
 
     assert excinfo.value.status_code == 400
     assert excinfo.value.error == LambdaError.CreateDocInvalidType

--- a/lambdas/utils/dynamo_utils.py
+++ b/lambdas/utils/dynamo_utils.py
@@ -159,7 +159,7 @@ class DocTypeTableRouter:
     def __init__(self, lg_dynamo_table: str, pdm_dynamo_table: str):
         self.mapping = {
             SnomedCodes.LLOYD_GEORGE.value.code: lg_dynamo_table,
-            SnomedCodes.UNSTRUCTURED.value.code: pdm_dynamo_table,
+            SnomedCodes.PATIENT_DATA.value.code: pdm_dynamo_table,
         }
 
     def resolve(self, doc_type: SnomedCode) -> str:


### PR DESCRIPTION
Allows POSTing to PDM routing.
- Determine client from the "common name" in the MTLS header.
- Set the SNOMED code to PATIENT_DATA if coming through mTLS and common name == pdm
- Set the database to PDM based on the SNOMED code
- Set the database based on mapping rather than a conditional. 
- Unit Tests